### PR TITLE
Add directory to fix object extensions loaderror

### DIFF
--- a/config/initializers/object_extensions.rb
+++ b/config/initializers/object_extensions.rb
@@ -1,1 +1,1 @@
-require 'object_extensions'
+require 'object_extensions/object_extensions'


### PR DESCRIPTION
Because the file object_extensions.rb is in
lib/object_extensions/object_extensions.rb (I think), I and travis were
getting "LoadError: cannot load such file -- object_extensions". This
fixes the error... there might be a better way to fix this though.
