### PR TITLE
Fix the error from using deprecated ActionController::Response

### DIFF
--- a/config/initializers/response_cache_timeout.rb
+++ b/config/initializers/response_cache_timeout.rb
@@ -1,3 +1,3 @@
-ActionController::Response.class_eval do
+ActionDispatch::Response.class_eval do
   attr_accessor :cache_timeout
 end


### PR DESCRIPTION
I was getting:

```
NameError: uninitialized constant ActionController::Response
trusty-cms/config/initializers/response_cache_timeout.rb:1:in
```

`<top (required)>'

which is because ActionController::Response has become
ActionDispatch::Response.
