### PR TITLE
Remove a monkey patch that is no longer needed

### DIFF
--- a/lib/object_extensions/object_extensions.rb
+++ b/lib/object_extensions/object_extensions.rb
@@ -1,7 +1,4 @@
 class Object
-  def self.descendants
-    subclasses_of(self)
-  end
   def presence
     return self if present?
   end


### PR DESCRIPTION
Rails 3 now just has Object#descendants instead of subclasses_of, soooo
done and done!
