### PR TITLE
Fix stylesheet and javascript override tags

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -163,13 +163,18 @@ module ApplicationHelper
     [[t('select.default'),'']] + TrustyCms::AvailableLocales.locales
   end
   
-  def stylesheet_and_javascript_overrides
-    overrides = ''
+  def stylesheet_overrides
+    overrides = []
     if File.exist?("#{Rails.root}/public/stylesheets/admin/overrides.css") || File.exist?("#{Rails.root}/public/stylesheets/sass/admin/overrides.sass")
-      overrides << stylesheet_link_tag('admin/overrides')
+      overrides << 'admin/overrides'
     end
+    overrides
+  end
+
+  def javascript_overrides
+    overrides = []
     if File.exist?("#{Rails.root}/public/javascripts/admin/overrides.js")
-      overrides << javascript_include_tag('admin/overrides')
+      overrides << 'admin/overrides'
     end
     overrides
   end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,7 +14,10 @@
     - if @content_for_page_css
       %style{:type => "text/css"}= @content_for_page_css
     = yield :meta
-    = stylesheet_and_javascript_overrides
+    - stylesheet_overrides.each do |stylesheet|
+      = stylesheet_link_tag stylesheet
+    - javascript_overrides.each do |javascript|
+      = javascript_include_tag javascript
   %body{:class=>body_classes.join(" ")}
     #page
       #header


### PR DESCRIPTION
They were being rendered as text rather than tags because Rails 3
automatically escapes strings that are not html_safe.

Fixes #23
