### PR TITLE
Output admin header as html_safe string

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,7 +23,7 @@
       #header
         - if logged_in?
           #site_links
-            = %{#{t('logged_in_as')} #{link_to h(current_user.name), edit_admin_preferences_path} &nbsp; (#{link_to t('log_out'), logout_path})}
+            = %{#{t('logged_in_as')} #{link_to h(current_user.name), edit_admin_preferences_path} &nbsp; (#{link_to t('log_out'), logout_path})}.html_safe
             &nbsp;
             = link_to t('view_site'), root_path, :id=>"view_site"
           %ul#navigation

--- a/spec/features/config_spec.rb
+++ b/spec/features/config_spec.rb
@@ -40,6 +40,12 @@ describe 'Configuration of a site' do
         expect(User.all.count).to equal 1
         expect(page).to have_content "Logged in as"
       end
+
+      it 'has correct links in header' do
+        expect(page).to have_link 'Test User', href: '/admin/preferences/edit'
+        expect(page).to have_link 'Logout', href: '/admin/logout'
+        expect(page).to have_link 'View Site', href: '/'
+      end
     end
   end
 end


### PR DESCRIPTION
Rails 2 outputs strings in views as-is, but Rails 3 escapes them by
default. We need to make them html safe strings to keep rails from
escaping them.

Fixes #34 for the header on the admin page layout.
