### PR TITLE
We don't need to be explicit about the failcase

### DIFF
--- a/app/helpers/admin/pages_helper.rb
+++ b/app/helpers/admin/pages_helper.rb
@@ -7,7 +7,7 @@ module Admin::PagesHelper
   end
   
   def filter
-    @page.parts.empty? ? nil : @page.parts.first.filter
+    @page.parts.first.filter if @page.parts.respond_to?(:any?) && @page.parts.any?
   end
   
   def meta_errors?


### PR DESCRIPTION
This simplifies the logic by using some of the affordances of Ruby.

It still returns nil, it doesn't fail if `Page#parts` returns something that doesn't respond to `#any?`, and pushes a "successful" primary result.
