### PR TITLE
Have sass-rails3 only in the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,6 @@ gemspec
 # gem "radiant-smarty_pants_filter-extension", "~> 1.0.2"
 # gem "radiant-textile_filter-extension",      "~> 1.0.4"
 
-  gem 'sass-rails3', '~> 4.0.1'
-
 group :development, :test do
   gem 'thin',        '~> 1.6.2'
   gem 'pry',         '~> 0.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,5 @@ DEPENDENCIES
   launchy (~> 2.4.2)
   pry (~> 0.10.0)
   rspec-rails (~> 3.0.0)
-  sass-rails3 (~> 4.0.1)
   thin (~> 1.6.2)
   trusty-cms!

--- a/trusty_cms.gemspec
+++ b/trusty_cms.gemspec
@@ -31,7 +31,7 @@ a general purpose content managment system--not merely a blogging engine.}
   s.add_dependency "compass-rails",   "~> 1.1.7"
   s.add_dependency "sprockets",       "= 2.2.2.backport2"
   s.add_dependency "sprockets-rails", "~> 2.0.0.backport1"
-  s.add_dependency "sass-rails3",            "= 4.0.1"
+  s.add_dependency "sass-rails3",     "= 4.0.1"
   s.add_dependency "delocalize",      "~> 0.2.3"
   s.add_dependency "haml",            "~> 4.0.5"
   s.add_dependency "haml-rails",      ">= 0.4", "< 0.5" # 0.5 is rails 4+ only


### PR DESCRIPTION
Since Eric released it as a proper gem, it works fine in the gemspec and
it doesn't need to be in the Gemfile anymore. Yay!!!!
