### PR TITLE
Register 2.0.23 to make TrustyCMS compatible with Ruby 2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (2.0.22)
+    trusty-cms (2.0.23)
       RedCloth (~> 4.3.2)
       acts_as_tree (~> 2.1)
       bundler (~> 1.7)

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -1,0 +1,54 @@
+# patching OpenStruct due to Ruby 2.3.1 upgrade
+# See more here: http://stackoverflow.com/questions/39278864/openstruct-issue-with-ruby-2-3-1/39280374#39280374
+
+class OpenStruct
+
+  def initialize(hash=nil)
+    @table = {}
+    if hash
+      hash.each_pair do |k, v|
+        k = k.to_sym
+        @table[k] = v
+        new_ostruct_member(k)
+      end
+    end
+  end
+
+  def modifiable
+    begin
+      @modifiable = true
+    rescue
+      raise RuntimeError, "can't modify frozen #{self.class}", caller(3)
+    end
+    @table
+  end
+  protected :modifiable
+
+  def new_ostruct_member(name)
+    name = name.to_sym
+    unless respond_to?(name)
+      define_singleton_method(name) { @table[name] }
+      define_singleton_method("#{name}=") { |x| modifiable[name] = x }
+    end
+    name
+  end
+  protected :new_ostruct_member
+
+  def method_missing(mid, *args) # :nodoc:
+    mname = mid.id2name
+    len = args.length
+    if mname.chomp!('=')
+      if len != 1
+        raise ArgumentError, "wrong number of arguments (#{len} for 1)", caller(1)
+      end
+      modifiable[new_ostruct_member(mname)] = args[0]
+    elsif len == 0
+      @table[mid]
+    else
+      err = NoMethodError.new "undefined method `#{mid}' for #{self}", mid, args
+      err.set_backtrace caller(1)
+      raise err
+    end
+  end
+
+end

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), "..")) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = "2.0.22"
+    VERSION = "2.0.23"
   end
 end


### PR DESCRIPTION
With the Ruby 2.3.1 upgrade, the class OpenStruct was failing because the hash that returns a new Response.new is not setting the default instance variables anymore. Just calling key? doesn't trigger the setting of the default value:

Ruby 2.2: https://github.com/ruby/ruby/blob/ruby_2_2/lib/ostruct.rb#L184-L186

Ruby 2.3: https://github.com/ruby/ruby/blob/trunk/lib/ostruct.rb#L204-L206

This forced me to patch OpenStruct to use the Ruby 2.2 behavior. Tests are passing and it runs smoothly on the Trust's websites. 