### PR TITLE
Collapse trusty-layouts-extension into TrustyCMS core

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    trusty-cms (3.1.2)
+    trusty-cms (3.1.3)
       RedCloth (~> 4.3.2)
       acts_as_tree (~> 2.6.1)
       bundler (~> 1.7)
@@ -137,7 +137,7 @@ GEM
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
-    haml (5.0.3)
+    haml (5.0.4)
       temple (>= 0.8.0)
       tilt
     haml-rails (1.0.0)
@@ -314,7 +314,6 @@ DEPENDENCIES
   simplecov
   trusty-cms!
   trustygems (~> 0.2.0)
-
 
 BUNDLED WITH
    1.16.0.pre.2

--- a/app/models/haml_filter.rb
+++ b/app/models/haml_filter.rb
@@ -1,0 +1,5 @@
+class HamlFilter < TextFilter
+  def filter(text)
+    Haml::Engine.new(text).render.gsub(/&lt;(\/)?r:(.+?)\s*(\/?\\?)&gt;/m,"<\\1r:\\2\\3>")
+  end
+end

--- a/app/models/rails_page.rb
+++ b/app/models/rails_page.rb
@@ -1,0 +1,39 @@
+class RailsPage < Page
+
+  display_name "Application"
+  attr_accessor :breadcrumbs
+
+  def find_by_url(url, live=true, clean=true)
+    found_page = super
+    if found_page.nil? || found_page.is_a?(FileNotFoundPage)
+      url = clean_url(url) if clean
+      self if url.starts_with?(self.url)
+    else
+      found_page
+    end
+  end
+  
+  def url=(path)
+    @url = path
+  end
+  
+  def url
+    @url || super
+  end
+  
+  def build_parts_from_hash!(content)
+    content.each do |k,v|
+      (part(k) || parts.build(:name => k.to_s, :filter_id => "")).content = v
+    end
+  end 
+  
+  alias_method "tag:old_breadcrumbs", "tag:breadcrumbs"
+  tag 'breadcrumbs' do |tag|
+    if tag.locals.page.is_a?(RailsPage) && tag.locals.page.breadcrumbs
+      tag.locals.page.breadcrumbs
+    else
+      render_tag('old_breadcrumbs', tag)
+    end
+  end
+  
+end

--- a/app/views/layouts/trusty.html.haml
+++ b/app/views/layouts/trusty.html.haml
@@ -1,0 +1,1 @@
+= trusty_layout.html_safe

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), "..")) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '3.1.2'
+    VERSION = '3.1.3'
   end
 end

--- a/vendor/extensions/layouts-extension/layouts_extension.rb
+++ b/vendor/extensions/layouts-extension/layouts_extension.rb
@@ -1,0 +1,19 @@
+class LayoutsExtension < TrustyCms::Extension
+  description "A set of useful extensions to standard Layouts."
+
+  def activate
+    # Shared Layouts
+    RailsPage
+    ApplicationController.send :include, ShareLayouts::Controllers::ActionController
+    ActionView::Base.send :include, ShareLayouts::Helpers::ActionView
+
+    # Nested Layouts
+    Page.send   :include, NestedLayouts::Tags::Core
+
+    # HAML Layouts
+    Layout.send  :include, HamlLayouts::Models::Layout
+    Page.send    :include, HamlLayouts::Models::Page
+    HamlFilter
+  end
+
+end

--- a/vendor/extensions/layouts-extension/lib/haml_layouts/models/layout.rb
+++ b/vendor/extensions/layouts-extension/lib/haml_layouts/models/layout.rb
@@ -1,0 +1,33 @@
+module HamlLayouts
+  module Models
+    module Layout
+      
+      def self.included(base)
+        base.class_eval do
+          
+          # Will render html from haml if necessary
+          def rendered_content
+            if is_haml?
+              # The gsub will replace all escaped radius tags with html
+              HamlFilter.filter(content)
+            else
+              content
+            end
+          end
+          
+          # Returns 'text/html' to the browser (if haml)           
+          def content_type
+            self[:content_type] == 'haml' ? 'text/html' : self[:content_type]
+          end
+
+          # Overwrites the standard Trusty CMS Render and pumps out haml if necessary
+          def is_haml?
+            self[:content_type] == 'haml'
+          end
+          
+        end
+      end
+      
+    end
+  end
+end

--- a/vendor/extensions/layouts-extension/lib/haml_layouts/models/page.rb
+++ b/vendor/extensions/layouts-extension/lib/haml_layouts/models/page.rb
@@ -1,0 +1,33 @@
+module HamlLayouts
+  module Models
+    module Page
+      
+      def self.included(base)
+        base.class_eval do
+          
+          def parse_object(object)
+            # We don't want to return the haml on a layout by default
+            text =  object.is_a?(Layout) ? object.rendered_content : object.content
+                        
+            if object.respond_to? :filter_id
+              if object.filter_id == 'Haml'
+                # We want to render the tags as html/radius before passing them
+                text = object.filter.filter(text)
+                text = parse(text)
+              else
+                text = parse(text)
+                text = object.filter.filter(text)
+              end
+            else
+              text = parse(text)
+            end
+            text
+          end
+          
+        end
+      end
+      
+    end
+  end
+end
+

--- a/vendor/extensions/layouts-extension/lib/layouts/engine.rb
+++ b/vendor/extensions/layouts-extension/lib/layouts/engine.rb
@@ -1,0 +1,5 @@
+module Layouts
+  class Engine < Rails::Engine
+    paths["app/helpers"] = []
+  end
+end

--- a/vendor/extensions/layouts-extension/lib/share_layouts/controllers/action_controller.rb
+++ b/vendor/extensions/layouts-extension/lib/share_layouts/controllers/action_controller.rb
@@ -1,0 +1,26 @@
+module ShareLayouts
+  module Controllers
+    module ActionController
+
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        def trusty_layout(name=nil, options={}, &block)
+          raise ArgumentError, "A layout name or block is required!" unless name || block
+          class_attribute :trusty_layout
+          self.trusty_layout = name || block
+          before_action :set_trusty_layout
+          layout 'trusty', options
+        end
+      end
+
+      def set_trusty_layout
+        @trusty_layout = self.class.trusty_layout
+        @trusty_layout = @trusty_layout.call(self) if @trusty_layout.is_a? Proc
+      end
+
+    end
+  end
+end

--- a/vendor/extensions/layouts-extension/lib/share_layouts/helpers/action_view.rb
+++ b/vendor/extensions/layouts-extension/lib/share_layouts/helpers/action_view.rb
@@ -1,0 +1,48 @@
+module ShareLayouts
+  module Helpers
+    module ActionView
+  
+        def self.included(base)
+          base.class_eval do
+            
+            def trusty_layout(name = @trusty_layout)
+              page = find_page
+              assign_attributes!(page, name)
+              page.build_parts_from_hash!(extract_captures)
+              page.render
+            end
+            
+            def assign_attributes!(page, name = @trusty_layout)
+              page.layout = Layout.where(name: name).first || page.layout
+              page.title = @title || @content_for_title || page.title || ''
+              page.breadcrumb = @breadcrumb || @content_for_breadcrumb || page.breadcrumb || page.title
+              page.breadcrumbs = @breadcrumbs || @content_for_breadcrumbs || nil
+              page.url = request.path
+              page.slug = page.url.split("/").last
+              page.published_at ||= Time.now 
+              page.request = request
+              page.response = response
+            end
+            
+            def extract_captures
+              @view_flow.content.inject({}) do |h, var|
+                key = var[0]
+                key = :body if key == :layout
+                unless key == :title || key == :breadcrumbs
+                  h[key] = var[1]
+                end
+                h
+              end
+            end
+            
+            def find_page
+              page = Page.find_by_url(request.path) rescue nil
+              page.is_a?(RailsPage) ? page : RailsPage.new(:class_name => "RailsPage")
+            end
+            
+          end
+        end
+      
+    end
+  end
+end

--- a/vendor/extensions/layouts-extension/lib/tasks/layouts_extension_tasks.rake
+++ b/vendor/extensions/layouts-extension/lib/tasks/layouts_extension_tasks.rake
@@ -1,0 +1,55 @@
+namespace :trusty_cms do
+  namespace :extensions do
+    namespace :layouts do
+      
+      desc "Runs the migration of the Layouts extension"
+      task :migrate => :environment do
+        require 'trusty/extension_migrator'
+        if ENV["VERSION"]
+          LayoutsExtension.migrator.migrate(ENV["VERSION"].to_i)
+          Rake::Task['db:schema:dump'].invoke
+        else
+          LayoutsExtension.migrator.migrate
+          Rake::Task['db:schema:dump'].invoke
+        end
+      end
+      
+      desc "Copies public assets of the Layouts to the instance public/ directory."
+      task :update => :environment do
+        is_svn_or_dir = proc {|path| path =~ /\.svn/ || File.directory?(path) }
+        puts "Copying assets from LayoutsExtension"
+        Dir[LayoutsExtension.root + "/public/**/*"].reject(&is_svn_or_dir).each do |file|
+          path = file.sub(LayoutsExtension.root, '')
+          directory = File.dirname(path)
+          mkdir_p Rails.root.to_s + directory, :verbose => false
+          cp file, Rails.root.to_s + path, :verbose => false
+        end
+        unless LayoutsExtension.root.starts_with? Rails.root.to_s # don't need to copy vendored tasks
+          puts "Copying rake tasks from LayoutsExtension"
+          local_tasks_path = File.join(Rails.root.to_s, %w(lib tasks))
+          mkdir_p local_tasks_path, :verbose => false
+          Dir[File.join LayoutsExtension.root, %w(lib tasks *.rake)].each do |file|
+            cp file, local_tasks_path, :verbose => false
+          end
+        end
+      end  
+      
+      desc "Syncs all available translations for this ext to the English ext master"
+      task :sync => :environment do
+        # The main translation root, basically where English is kept
+        language_root = LayoutsExtension.root + "/config/locales"
+        words = TranslationSupport.get_translation_keys(language_root)
+        
+        Dir["#{language_root}/*.yml"].each do |filename|
+          next if filename.match('_available_tags')
+          basename = File.basename(filename, '.yml')
+          puts "Syncing #{basename}"
+          (comments, other) = TranslationSupport.read_file(filename, basename)
+          words.each { |k,v| other[k] ||= words[k] }  # Initializing hash variable as empty if it does not exist
+          other.delete_if { |k,v| !words[k] }         # Remove if not defined in en.yml
+          TranslationSupport.write_file(filename, basename, comments, other)
+        end
+      end
+    end
+  end
+end

--- a/vendor/extensions/layouts-extension/lib/trusty-layouts-extension.rb
+++ b/vendor/extensions/layouts-extension/lib/trusty-layouts-extension.rb
@@ -1,0 +1,1 @@
+# Nothing to see here


### PR DESCRIPTION
Retires the need to maintain: https://github.com/pgharts/trusty-layouts-extension