### PR TITLE
Collapse trusty-snippets-extension into TrustyCMS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    trusty-cms (3.1.6)
+    trusty-cms (3.1.7)
       RedCloth (~> 4.3.2)
       acts_as_tree (~> 2.6.1)
       bundler (~> 1.7)
@@ -318,7 +318,6 @@ DEPENDENCIES
   simplecov
   trusty-cms!
   trustygems (~> 0.2.0)
-
 
 BUNDLED WITH
    1.16.0

--- a/app/controllers/admin/snippets_controller.rb
+++ b/app/controllers/admin/snippets_controller.rb
@@ -1,0 +1,8 @@
+class Admin::SnippetsController < Admin::ResourceController
+  paginate_models
+  only_allow_access_to :index, :show, :new, :create, :edit, :update, :remove, :destroy,
+    :when => [:designer, :admin],
+    :denied_url => { :controller => 'admin/pages', :action => 'index' },
+    :denied_message => 'You must have designer privileges to perform this action.'
+  
+end

--- a/app/helpers/admin/snippets_helper.rb
+++ b/app/helpers/admin/snippets_helper.rb
@@ -1,3 +1,0 @@
-module Admin::SnippetsHelper
-
-end

--- a/app/helpers/admin/snippets_helper.rb
+++ b/app/helpers/admin/snippets_helper.rb
@@ -1,0 +1,3 @@
+module Admin::SnippetsHelper
+
+end

--- a/app/views/snippets/_form.html.haml
+++ b/app/views/snippets/_form.html.haml
@@ -1,0 +1,29 @@
+= form_for [:admin, @snippet], :html => {'data-onsubmit_status' => onsubmit_status(@snippet)} do |f|
+  = f.hidden_field :lock_version
+  = render_region :form_top, :locals => {:f => f}
+  .form_area
+    - render_region :form, :locals => {:f => f} do |form|
+      - form.edit_title do
+        %p.title
+          = f.label :name, t('name')
+          = f.text_field :name, :class => 'textbox activate', :maxlength => 100
+      - form.edit_content do
+        %p.content
+          = f.label :content, t('body')
+          ~ f.text_area :content, :class => "textarea large", :style => "width: 100%"
+      - form.edit_filter do
+        .set
+          %p
+            %span.reference_links
+              == #{t('reference')}:
+              %span{:id => "tag_reference_link"}
+                = link_to t('available_tags'), admin_reference_url(:tags), id: 'tag_reference'
+  - render_region :form_bottom, :locals => {:f => f} do |form_bottom|
+    - form_bottom.edit_buttons do
+      .buttons{:style=>"clear: left"}
+        = save_model_button(@snippet)
+        = save_model_and_continue_editing_button(@snippet)
+        = t('or')
+        = link_to t('cancel'), admin_snippets_url
+    - form_bottom.edit_timestamp do
+      = updated_stamp @snippet

--- a/app/views/snippets/_popups.html.haml
+++ b/app/views/snippets/_popups.html.haml
@@ -1,0 +1,4 @@
+- content_for :popups do
+  #popup_window
+    .outer
+      .content

--- a/app/views/snippets/edit.html.haml
+++ b/app/views/snippets/edit.html.haml
@@ -1,0 +1,11 @@
+- @page_title = @snippet.name + ' ' + t('snippet') + ' - ' + default_page_title
+
+- render_region :main do |main|
+  - main.edit_header do
+    %h1= t('edit_snippet')  
+  - main.edit_form do
+    = render :partial => 'form'
+  - main.edit_popups do
+    = render :partial => "popups"
+
+- content_for 'page_scripts'

--- a/app/views/snippets/index.html.haml
+++ b/app/views/snippets/index.html.haml
@@ -1,0 +1,33 @@
+- @page_title = t('snippets') + ' - ' + default_page_title
+
+.outset
+  = render_region :top
+  %table.index#snippets
+    %thead
+      %tr
+        - render_region :thead do |thead|
+          - thead.title_header do
+            %th.name= t('snippet')
+          - thead.actions_header do
+            %th.actions{:style=>"width:9em"}= t('modify')
+    %tbody
+      - if @snippets.any?
+        - @snippets.each do |snippet|
+          %tr[snippet]
+            - render_region :tbody, :locals => {:snippet => snippet} do |tbody|
+              - tbody.title_cell do
+                %td.name
+                  = link_to image('snippet', :alt => '') + ' ' + snippet.name, edit_admin_snippet_url(snippet)
+              - tbody.actions_cell do
+                %td.actions
+                  = link_to image('minus') + ' ' + t('remove'), remove_admin_snippet_url(snippet), :class => "action"
+      - else
+        %tr
+          %td.empty{:colspan => admin.snippet.index.tbody.length}= t('no_snippets')
+
+- render_region :bottom do |bottom|
+  - bottom.new_button do
+    #actions
+      = pagination_for(@snippets)
+      %ul
+        %li= link_to image('plus') + " " + t('new_snippet'), new_admin_snippet_url, :class => 'action_button'

--- a/app/views/snippets/new.html.haml
+++ b/app/views/snippets/new.html.haml
@@ -1,0 +1,9 @@
+- render_region :main do |main|
+  - main.edit_header do
+    %h1= t('new_snippet')  
+  - main.edit_form do
+    = render :partial => 'form'
+  - main.edit_popups do
+    = render :partial => "popups"
+
+- content_for 'page_scripts'

--- a/app/views/snippets/remove.html.haml
+++ b/app/views/snippets/remove.html.haml
@@ -1,0 +1,17 @@
+%h1= t('remove_snippet')
+
+%p 
+  = t('text.snippets.remove_warning')
+
+%table.index#snippets
+  %tbody
+    %tr.node.level_1
+      %td.snippet
+        = image('snippet', :alt => "")
+        %span.title= @snippet.name
+
+= form_for [:admin, @snippet], :html => {:method => :delete, 'data-onsubmit_status'=>"Removing snippet&#8230;"} do
+  .buttons
+    %input.button{:type=>"submit", :value => t('delete_snippet')}/
+    = t('or')
+    = link_to t('cancel'), admin_snippets_url

--- a/config/initializers/trusty_cms_config.rb
+++ b/config/initializers/trusty_cms_config.rb
@@ -15,3 +15,7 @@ TrustyCms.config do |config|
   config.define 'user.allow_password_reset?', :default => true
   config.define 'session_timeout', :default => 2.weeks
 end
+
+if TrustyCms.config_definitions['defaults.snippet.filter'].nil?
+  TrustyCms.config.define 'defaults.snippet.filter', :select_from => lambda { TextFilter.descendants.map { |s| s.filter_name }.sort }, :allow_blank => true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,9 @@ TrustyCms::Application.routes.draw do
     resources :users do
       get 'remove', on: :member
     end
+    resources :snippets do
+      get :remove, on: :member
+    end
     resources :password_resets
     post 'save-table-position' => "pages#save_table_position", as: "save_tables_position"
   end

--- a/lib/tasks/snippets_extension_tasks.rake
+++ b/lib/tasks/snippets_extension_tasks.rake
@@ -1,0 +1,47 @@
+namespace :trusty do
+  namespace :extensions do
+    namespace :snippets do
+      
+      desc "Runs the migration of the Snippets extension"
+      task :migrate => :environment do
+        require 'trusty_cms/extension_migrator'
+        if ENV["VERSION"]
+          SnippetsExtension.migrator.migrate(ENV["VERSION"].to_i)
+          Rake::Task['db:schema:dump'].invoke
+        else
+          SnippetsExtension.migrator.migrate
+          Rake::Task['db:schema:dump'].invoke
+        end
+      end
+      
+      desc "Copies public assets of the Snippets to the instance public/ directory."
+      task :update => :environment do
+        is_svn_or_dir = proc {|path| path =~ /\.svn/ || File.directory?(path) }
+        puts "Copying assets from SnippetsExtension"
+        Dir[SnippetsExtension.root + "/public/**/*"].reject(&is_svn_or_dir).each do |file|
+          path = file.sub(SnippetsExtension.root, '')
+          directory = File.dirname(path)
+          mkdir_p RAILS_ROOT + directory, :verbose => false
+          cp file, RAILS_ROOT + path, :verbose => false
+        end
+      end  
+      
+      desc "Syncs all available translations for this ext to the English ext master"
+      task :sync => :environment do
+        # The main translation root, basically where English is kept
+        language_root = SnippetsExtension.root + "/config/locales"
+        words = TranslationSupport.get_translation_keys(language_root)
+        
+        Dir["#{language_root}/*.yml"].each do |filename|
+          next if filename.match('_available_tags')
+          basename = File.basename(filename, '.yml')
+          puts "Syncing #{basename}"
+          (comments, other) = TranslationSupport.read_file(filename, basename)
+          words.each { |k,v| other[k] ||= words[k] }  # Initializing hash variable as empty if it does not exist
+          other.delete_if { |k,v| !words[k] }         # Remove if not defined in en.yml
+          TranslationSupport.write_file(filename, basename, comments, other)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/snippets_extension_tasks.rake
+++ b/lib/tasks/snippets_extension_tasks.rake
@@ -2,43 +2,43 @@ namespace :trusty do
   namespace :extensions do
     namespace :snippets do
       
-      desc "Runs the migration of the Snippets extension"
+      desc 'Runs the migration of the Snippets extension'
       task :migrate => :environment do
         require 'trusty_cms/extension_migrator'
-        if ENV["VERSION"]
-          SnippetsExtension.migrator.migrate(ENV["VERSION"].to_i)
+        if ENV['VERSION']
+          SnippetsExtension.migrator.migrate(ENV['VERSION'].to_i)
           Rake::Task['db:schema:dump'].invoke
         else
           SnippetsExtension.migrator.migrate
           Rake::Task['db:schema:dump'].invoke
         end
       end
-      
-      desc "Copies public assets of the Snippets to the instance public/ directory."
+
+      desc 'Copies public assets of the Snippets to the instance public/ directory.'
       task :update => :environment do
         is_svn_or_dir = proc {|path| path =~ /\.svn/ || File.directory?(path) }
-        puts "Copying assets from SnippetsExtension"
-        Dir[SnippetsExtension.root + "/public/**/*"].reject(&is_svn_or_dir).each do |file|
+        puts 'Copying assets from SnippetsExtension'
+        Dir[SnippetsExtension.root + '/public/**/*'].reject(&is_svn_or_dir).each do |file|
           path = file.sub(SnippetsExtension.root, '')
           directory = File.dirname(path)
-          mkdir_p RAILS_ROOT + directory, :verbose => false
-          cp file, RAILS_ROOT + path, :verbose => false
+          mkdir_p Rails.root + directory, :verbose => false
+          cp file, Rails.root + path, :verbose => false
         end
-      end  
+      end
       
-      desc "Syncs all available translations for this ext to the English ext master"
+      desc 'Syncs all available translations for this ext to the English ext master'
       task :sync => :environment do
         # The main translation root, basically where English is kept
-        language_root = SnippetsExtension.root + "/config/locales"
+        language_root = SnippetsExtension.root + '/config/locales'
         words = TranslationSupport.get_translation_keys(language_root)
         
-        Dir["#{language_root}/*.yml"].each do |filename|
+        Dir['#{language_root}/*.yml'].each do |filename|
           next if filename.match('_available_tags')
           basename = File.basename(filename, '.yml')
           puts "Syncing #{basename}"
           (comments, other) = TranslationSupport.read_file(filename, basename)
-          words.each { |k,v| other[k] ||= words[k] }  # Initializing hash variable as empty if it does not exist
-          other.delete_if { |k,v| !words[k] }         # Remove if not defined in en.yml
+          words.each { |k, v| other[k] ||= words[k] }  # Initializing hash variable as empty if it does not exist
+          other.delete_if { |k, v| !words[k] }         # Remove if not defined in en.yml
           TranslationSupport.write_file(filename, basename, comments, other)
         end
       end

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), "..")) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '3.1.6'
+    VERSION = '3.1.7'
   end
 end


### PR DESCRIPTION
* Collapse the trusty-snippets-extension modules into TrustyCMS core. This retires the snippets extension. 
* Register TrustyCMS 3.1.7 

