### PR TITLE
Remove Compass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,5 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'rails-observers'
   gem 'rspec-rails'
+  gem 'sass-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       acts_as_tree (>= 2.6.1, < 2.9.0)
       bundler (~> 1.7)
       ckeditor (>= 4.2.2, < 4.4.0)
-      compass-rails (>= 3.0.2, < 3.2.0)
       delocalize (>= 0.2, < 2.0)
       execjs (~> 2.7)
       haml (~> 5.0)
@@ -91,7 +90,6 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
-    chunky_png (1.3.11)
     ckeditor (4.3.0)
       orm_adapter (~> 0.5.0)
       terrapin
@@ -100,22 +98,6 @@ GEM
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
     coderay (1.1.2)
-    compass (1.0.3)
-      chunky_png (~> 1.2)
-      compass-core (~> 1.0.2)
-      compass-import-once (~> 1.0.5)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-      sass (>= 3.3.13, < 3.5)
-    compass-core (1.0.3)
-      multi_json (~> 1.0)
-      sass (>= 3.3.0, < 3.5)
-    compass-import-once (1.0.5)
-      sass (>= 3.2, < 3.5)
-    compass-rails (3.1.0)
-      compass (~> 1.0.0)
-      sass-rails (< 5.1)
-      sprockets (< 4.0)
     concurrent-ruby (1.1.4)
     crass (1.0.4)
     css_parser (1.6.0)
@@ -133,8 +115,8 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
-    ffi (1.9.25)
-    globalid (0.4.1)
+    ffi (1.10.0)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)
       temple (>= 0.8.0)
@@ -145,7 +127,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
-    highline (2.0.0)
+    highline (2.0.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -180,7 +162,6 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mysql2 (0.5.2)
@@ -268,7 +249,11 @@ GEM
     rspec-support (3.8.0)
     ruby_parser (3.12.0)
       sexp_processor (~> 4.9)
-    sass (3.4.25)
+    sass (3.7.3)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
@@ -326,8 +311,9 @@ DEPENDENCIES
   pry-byebug
   rails-observers
   rspec-rails
+  sass-rails
   trusty-cms!
   trustygems (~> 0.2.0)
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/app/assets/stylesheets/admin/_base.scss
+++ b/app/assets/stylesheets/admin/_base.scss
@@ -14,4 +14,3 @@ $primary-tab-current: white;
 // Modules
 @import "modules/links";
 @import "modules/boxes";
-@import "modules/gradients";

--- a/app/assets/stylesheets/admin/_reset.scss
+++ b/app/assets/stylesheets/admin/_reset.scss
@@ -1,0 +1,55 @@
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font: inherit;
+  font-size: 100%;
+  vertical-align: baseline;
+}
+
+html {
+  line-height: 1;
+}
+
+ol, ul {
+  list-style: none;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+caption, th, td {
+  text-align: left;
+  font-weight: normal;
+  vertical-align: middle;
+}
+
+q, blockquote {
+  quotes: none;
+}
+q:before, q:after, blockquote:before, blockquote:after {
+  content: "";
+  content: none;
+}
+
+a img {
+  border: none;
+}
+
+article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
+  display: block;
+}

--- a/app/assets/stylesheets/admin/_site_chooser.scss
+++ b/app/assets/stylesheets/admin/_site_chooser.scss
@@ -45,7 +45,6 @@ $black: #000;
 		}
 		&.site-link:hover {
 			color: $color_turquoise_blue_approx;
-			//Instead of the line below you could use @include transition($transition-1, $transition-2, $transition-3, $transition-4, $transition-5, $transition-6, $transition-7, $transition-8, $transition-9, $transition-10)
 			transition: all 0.2s;
 		}
 	}
@@ -57,19 +56,17 @@ $black: #000;
 		margin-top: 10px;
 		visibility: hidden;
 		opacity: 0;
-		//Instead of the line below you could use @include transition($transition-1, $transition-2, $transition-3, $transition-4, $transition-5, $transition-6, $transition-7, $transition-8, $transition-9, $transition-10)
 		transition: opacity 0.2s;
 		li {
 			float: none;
 		}
 		a {
-			white-space: nowrap; 
+			white-space: nowrap;
 		}
 	}
 	&:hover ul {
 		visibility: visible;
 		opacity: 1;
-		//Instead of the line below you could use @include transition($transition-1, $transition-2, $transition-3, $transition-4, $transition-5, $transition-6, $transition-7, $transition-8, $transition-9, $transition-10)
 		transition: opacity 0.2s;
 		z-index: 99999;
 	}

--- a/app/assets/stylesheets/admin/assets.scss
+++ b/app/assets/stylesheets/admin/assets.scss
@@ -1,9 +1,7 @@
-@import "compass";
-
 p.asset {
   img.preview {
     border: 5px solid white;
-    @include box-shadow;
+    box-shadow: 0 5px #333;
 }
 }
 
@@ -11,7 +9,7 @@ p.asset {
   float: left;
   padding: 2px 0;
   a {
-    @include border-radius(100px);
+    border-radius: 100px;
     color: #555555;
     padding: 3px 8px;
     text-decoration: none;
@@ -21,12 +19,12 @@ p.asset {
   }
     &.pressed {
       background: #888888;
-      @include box-shadow(0, 1px, 1px, #333333, inset);
+      box-shadow: inset 0 1px 1px #333;
       color: white;
       text-shadow: 0 1px 0 #333333;
       &:hover {
         background: #888888;
-        @include box-shadow(0, 1px, 1px, #333333, inset);
+        box-shadow: inset 0 1px 1px #333;
         color: white;
         text-shadow: 0 1px 0 #333333;
     }
@@ -37,14 +35,18 @@ p.asset {
 .popup {
   div.toolbar {
     background: white;
-    @include background-image(linear-gradient(white, #dddddd));
+    background-image: linear-gradient(#ffffff, #dddddd);
     border-bottom: 1px solid #cccccc;
-    @include single-box-shadow(white, 0, 1px, 0);
+    box-shadow: 0 1px 0 white;
     margin: -20px -20px 0;
     padding: 6px 10px 3px 10px;
     font-size: 95%;
     height: 30px;
-    @include clearfix;
+    &:after {
+      clear: both;
+      content: "";
+      display: block;
+    }
     .right {
       float: right;
   }
@@ -52,13 +54,13 @@ p.asset {
       padding: 4px 2px 0;
       input[type=search] {
         font-size: 12px;
-        @include border-radius(100px);
+        border-radius: 100px;
         border: 1px solid #cccccc;
         border-top-color: #999999;
         border-left-color: #b0b0b0;
         border-right-color: #bbbbbb;
         background: white url("/assets/admin/search.png") 4px center no-repeat;
-        @include box-shadow(rgba(black, 0.2), 0, 1px, 0, inset);
+        box-shadow: inset 0 1px 0 rgba(black, 0.2);
         width: 180px;
         padding: 2px 8px 2px 20px;
     }
@@ -85,8 +87,13 @@ p.asset {
   text-align: right;
   margin-bottom: -1em;
   ul {
-    @include inline-list;
-}
+    list-style-type: none;
+    &, & li {
+      margin: 0;
+      padding: 0;
+      display: inline;
+    }
+  }
   li {
     padding-left: 1em;
 }
@@ -119,13 +126,13 @@ p.asset {
         text-align: center;
     }
       .front {
-        @include box-shadow;
+        box-shadow: 0 5px #333;
         text-align: center;
     }
       .back {
         color: #333333;
         overflow: hidden;
-        @include opacity(0);
+        opacity: 0;
     }
       .title {
         color: #333333;
@@ -152,7 +159,7 @@ p.asset {
         a {
           background: #666666;
           background: rgba(black, 0.8);
-          @include border-radius;
+          border-radius: 5px;
           color: #dddddd;
           display: block;
           padding: 2px 10px;
@@ -171,7 +178,7 @@ p.asset {
     }
       &:hover {
         .back {
-          @include opacity(1);
+          opacity: 1;
           background: rgba(white, 0.6);
       }
     }
@@ -192,7 +199,8 @@ p.asset {
 }
 
 #attachment_list.assets {
-  @include border-bottom-radius;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius:: 5px;
   margin: -1em 0.5em 1em 0.5em;
   overflow-y: hidden;
   overflow-x: auto;
@@ -251,7 +259,7 @@ p.asset {
       float: left;
       padding: 0.25em;
       margin: 1em 2px 1em 0;
-      @include border-radius(2px);
+      border-radius: 2px;
       text-decoration: none;
   }
     span.current {

--- a/app/assets/stylesheets/admin/main.scss
+++ b/app/assets/stylesheets/admin/main.scss
@@ -1,10 +1,8 @@
 // main.css - main stylesheet for the TrustyCms admin interface
 
 // Common Variables and Modules
-@import "compass";
 @import "base";
-
-@import "compass/reset";
+@import "reset";
 
 // Partials
 @import "partials/typography";

--- a/app/assets/stylesheets/admin/modules/_boxes.scss
+++ b/app/assets/stylesheets/admin/modules/_boxes.scss
@@ -1,7 +1,7 @@
 @mixin alt-box {
+  background-image: linear-gradient(to bottom, #ffffff, #cccccc);
   background: #d8d8d8;
-  @include linear-gradient(color-stops(white, #cccccc));
-  @include border-radius(8px);
-  @include single-box-shadow(rgba(0, 0, 0, 0.15), 2px, 2px, 3px);
+  border-radius: 8px;
+  box-shadow: rgba(0, 0, 0, 0.15) 2px 2px 3px;
   padding: 12px 10px;
 }

--- a/app/assets/stylesheets/admin/modules/_gradients.scss
+++ b/app/assets/stylesheets/admin/modules/_gradients.scss
@@ -1,5 +1,0 @@
-// Reproduce the deprecated Compass linear-gradient mixin
-
-@mixin linear-gradient($color-stops, $start: top, $image: false) {
-  @include background-image($image, linear-gradient($start, $color-stops));
-}

--- a/app/assets/stylesheets/admin/partials/_actions.scss
+++ b/app/assets/stylesheets/admin/partials/_actions.scss
@@ -1,9 +1,9 @@
 @mixin button-shadow {
-  @include single-box-shadow(#555555, 1px, 2px, 3px);
+  box-shadow: 1px 2px 3px #555;
 }
 
 @mixin no-button-shadow {
-  @include single-box-shadow(#555555, 0, 0, 0);
+  box-shadow: 0 0 0 #555;
 }
 
 #actions {
@@ -12,7 +12,7 @@
   right: 0;
   bottom: 0;
   background: #777777;
-  @include linear-gradient(color-stops(#555555, #666666, #777777, #777777));
+  background-image: linear-gradient(to bottom, #555555, #666666, #777777, #777777);
   ul {
     padding: 14px 8px;
   }
@@ -32,18 +32,20 @@
       padding: 6px 12px 6px 12px;
       margin-right: 1px;
       background: #dddddd;
-      @include linear-gradient(color-stops(#c5c5c5, #f0f0f0 20%, white 35%, white));
+      background-image: linear-gradient(to bottom, #c5c5c5, #f0f0f0 20%, #ffffff 35%, #ffffff);
       color: #999999;
       font-size: 80%;
       text-decoration: none;
-      @include border-bottom-radius(5px);
-      @include border-top-radius(0);
+      border-bottom-left-radius: 5px;
+      border-bottom-right-radius:: 5px;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
     }
     a {
       text-shadow: 1px 1px 1px #eeeeee;
       &:hover {
         background: #d8d8d8;
-        @include linear-gradient(color-stops(white, white, #dddddd));
+        background-image: linear-gradient(to bottom, #ffffff, #ffffff, #dddddd);
         color: #0076a3;
         @include button-shadow;
       }
@@ -55,7 +57,7 @@
     span.disabled {
       color: #666666;
       background-color: #999999;
-      @include linear-gradient(color-stops(#888888, #999999, #999999, #999999));
+      background-image: linear-gradient(to bottom, #888888, #999999, #999999, #999999);
     }
     span.current {
       color: black;
@@ -95,13 +97,13 @@
 .action_button {
   display: inline;
   background: #d8d8d8;
-  @include linear-gradient(color-stops(white, #cccccc));
+  background-image: linear-gradient(to bottom, #ffffff, #cccccc);
   color: #333333;
   font-size: 80%;
   padding: 8px 12px;
   text-decoration: none;
   text-shadow: 1px 1px 1px #eeeeee;
-  @include border-radius(5px);
+  border-radius: 5px;
   @include button-shadow;
   &:hover {
     color: #0076a3;

--- a/app/assets/stylesheets/admin/partials/_avatars.scss
+++ b/app/assets/stylesheets/admin/partials/_avatars.scss
@@ -2,11 +2,11 @@ img.avatar {
   background: white;
   border: none;
   padding: 4px;
-  @include border-radius(3px);
-  @include single-box-shadow(rgba(0, 0, 0, 0.25), 1px, 1px, 3px);
+  border-radius: 3px;
+  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
   &.avatar_32x32 {
     padding: 2px;
-    @include border-radius(2px);
-    @include single-box-shadow(rgba(0, 0, 0, 0.3), 1px, 1px, 2px);
+    border-radius: 2px;
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
   }
 }

--- a/app/assets/stylesheets/admin/partials/_content.scss
+++ b/app/assets/stylesheets/admin/partials/_content.scss
@@ -70,10 +70,10 @@ body.reversed {
   position: fixed;
   top: 10px;
   right: 20px;
-  @include opacity(0.7);
+  opacity: 0.7;
   @include alt-box;
   &:hover {
-    @include opaque;
+    opacity: 1;
   }
   a {
     @include alt-link;

--- a/app/assets/stylesheets/admin/partials/_dateinput.scss
+++ b/app/assets/stylesheets/admin/partials/_dateinput.scss
@@ -5,15 +5,15 @@ input.date {
 }
 
 .calendar_popup {
-  @include single-box-shadow;
-  @include border-radius;
+  box-shadow: 0 5px #333;
+  border-radius: 5px;
   z-index: 1000;
   border: 1px solid #b2b2b2;
   background-color: white;
   padding: 5px;
   line-height: 140% !important;
   a {
-    @include border-radius;
+    border-radius: 5px;
   }
   table.calendar {
     font-size: 90%;
@@ -37,7 +37,7 @@ input.date {
       padding: 3px !important;
       margin: 0;
       &.today {
-        @include border-radius;
+        border-radius: 5px;
         background-color: #e5e5e5;
       }
       &.today a {

--- a/app/assets/stylesheets/admin/partials/_deprecated.scss
+++ b/app/assets/stylesheets/admin/partials/_deprecated.scss
@@ -30,7 +30,7 @@ table.index td.note {
 // Use a div with a class of "popup_title" instead of an h3 with a class of "title"
 div.popup h3.title {
   background: #c5dff5;
-  @include linear-gradient(color_stops(#e5f5ff, #c5dff5));
+  background-image: linear-gradient(to bottom, #e5f5ff, #c5dff5);
   border-bottom: 1px solid #a7cdf0;
   font-size: 100%;
   margin: -10px -20px 20px -20px;
@@ -41,13 +41,13 @@ div.popup h3.title {
 #actions {
   a {
     background: #d8d8d8;
-    @include linear-gradient(color-stops(white, #cccccc));
+    background-image: linear-gradient(to bottom, #ffffff, #cccccc);
     color: #333333;
     font-size: 80%;
     padding: 8px 12px;
     text-decoration: none;
     text-shadow: 1px 1px 1px #eeeeee;
-    @include border-radius(5px);
+    border-radius: 5px;
     @include button-shadow;
     &:hover {
       color: #0076a3;

--- a/app/assets/stylesheets/admin/partials/_dropdown.scss
+++ b/app/assets/stylesheets/admin/partials/_dropdown.scss
@@ -1,17 +1,19 @@
 .dropdown_wrapper {
   border: 1px solid #b3b3b3;
   border-top: 1px solid #c3c3c3;
-  @include single-box-shadow(rgba(0, 0, 0, 0.35), 0px, 8px, 25px);
-  @include border-top-right-radius;
-  @include border-bottom-radius;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.35);
+  border-top-right-radius:: 5px;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius:: 5px;
 }
 
 ul.menu {
   background: white;
   font-size: 80%;
   padding: 5px 20px;
-  @include border-top-right-radius;
-  @include border-bottom-radius;
+  border-top-right-radius:: 5px;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius:: 5px;
   li {
     margin: 0 -20px;
     &.separator {
@@ -28,7 +30,7 @@ ul.menu {
     &:hover {
       background: #e0f0ff;
       border-top: 1px solid #d5f0ff;
-      @include linear-gradient(color_stops(#e5f5ff, #b5d0f5));
+      background-image: linear-gradient(to bottom, #e5f5ff, #b5d0f5);
     }
   }
 }

--- a/app/assets/stylesheets/admin/partials/_forms.scss
+++ b/app/assets/stylesheets/admin/partials/_forms.scss
@@ -60,7 +60,7 @@
           padding: 0.2em 0.5em 0.3em;
           text-decoration: none;
           text-shadow: 0px 0px 20px rgba(255, 255, 255, 0.1);
-          @include border-radius(4px);
+          border-radius: 4px;
           &:hover {
             background-color: #555555;
           }
@@ -95,7 +95,7 @@
 
 .drawer_contents {
   background: #c9c9c9;
-  @include border-bottom-right-radius(6px);
+  border-bottom-right-radius: 6px;
   margin: 0;
   margin-right: 2px;
   padding-bottom: 2px;
@@ -104,7 +104,7 @@
     content: "\0020";
     display: block;
     width: 100%;
-    @include linear-gradient(color-stops(rgba(black, 0.3), rgba(black, 0)));
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0));
     height: 3px;
     margin-bottom: -3px;
   }
@@ -167,7 +167,8 @@
     top: -1px;
     text-shadow: #666666 1px 1px 0;
     text-decoration: none;
-    @include border-bottom-radius(6px);
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius:: 6px;
     &:hover,
     &:active,
     &:focus {
@@ -189,16 +190,19 @@
   padding: 1px 15px 10px;
   position: relative;
   margin: 3px 0 20px;
-  @include border-radius(8px);
-  @include pie-clearfix;
+  border-radius: 8px;
+  &:after {
+    clear: both;
+    content: "";
+    display: block;
+  }
   * {
     position: relative;
   }
   &:before {
-    @include linear-gradient(color-stops(white,
-    #f5f1e2 50%,
-    #f5f1e2));
-    @include border-top-radius(10px);
+    background-image: linear-gradient(to bottom, #ffffff, #f5f1e2 50%, #f5f1e2);
+    border-top-left-radius: 10px;
+    border-top-right-radius:: 10px;
     content: "\0020";
     display: block;
     position: absolute;
@@ -298,11 +302,8 @@ body.reversed {
         padding: 20px 15px;
         margin-bottom: 20px;
         overflow: hidden;
-        @include single-box-shadow(#ababab,
-        1px,
-        1px,
-        0);
-        @include border-radius(8px);
+        box-shadow: 1px 1px 0 #ababab;
+        border-radius: 8px;
         h3 {
           font-weight: bold;
           font-size: 120%;
@@ -333,13 +334,7 @@ body.reversed {
       border-radius: 5px;
     }
     .box {
-      @include single-box-shadow(rgba(0,
-      0,
-      0,
-      0.15),
-      2px,
-      2px,
-      3px);
+      box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.15);
     }
   }
 }
@@ -348,15 +343,13 @@ body.single_form {
   #content {
     #single_form {
       background: #f5f1e2;
-      @include linear-gradient(color-stops(#fdfcf9,
-      #f5f1e2 25%,
-      #f5f1e2));
+      background-image: linear-gradient(to bottom, #fdfcf9, #f5f1e2 25%, #f5f1e2);
       border: 0.35em solid #efead3;
       padding: 0.5em 1.5em;
       padding-right: 22px;
       position: relative;
       width: 28em;
-      @include border-radius(6px);
+      border-radius: 6px;
       h1 {
         font-size: 140%;
         margin: 0.75em 0 1.25em;

--- a/app/assets/stylesheets/admin/partials/_header.scss
+++ b/app/assets/stylesheets/admin/partials/_header.scss
@@ -1,7 +1,7 @@
 #header {
   font-size: 90%;
   background: $header;
-  @include linear-gradient(color-stops(darken($header, 12), $header, $header));
+  background-image: linear-gradient(to bottom, #000000, #000000, #000000);
   position: relative;
   &:after {
     content: "\0020";
@@ -11,7 +11,7 @@
     height: 2px;
     width: 100%;
     position: absolute;
-    @include linear-gradient(color-stops(rgba(black, 0.3), rgba(black, 0)));
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0));
   }
 }
 
@@ -32,7 +32,7 @@
 #view_site {
   font-size: 90%;
   background: rgba(black, 0.45);
-  @include border-radius;
+  border-radius: 5px;
   display: inline;
   padding: 3px 10px 4px;
   text-decoration: none;
@@ -55,7 +55,8 @@ ul#navigation {
       padding: 0 20px;
       position: relative;
       text-decoration: none;
-      @include border-top-radius(6px);
+      border-top-left-radius: 6px;
+      border-top-right-radius:: 6px;
     }
     &:hover a {
       background: opacify($primary-tab, 0.2);
@@ -71,13 +72,17 @@ ul#navigation {
 
 #toolbar {
   background: white;
-  @include linear-gradient(color-stops(white, darken(white, 5%), darken(white, 20%)));
+  background-image: linear-gradient(to bottom, #ffffff, #f2f2f2, #cccccc);
   font-size: 95%;
   clear: both;
   margin: 0;
   width: 100%;
   height: 38px;
-  @include pie-clearfix;
+  &:after {
+    clear: both;
+    content: "";
+    display: block;
+  }
   .right {
     float: right;
   }
@@ -85,13 +90,13 @@ ul#navigation {
     padding: 8px 8px 0;
     input[type=search] {
       font-size: 12px;
-      @include border-radius(100px);
+      border-radius: 100px;
       border: 1px solid #cccccc;
       border-top-color: #999999;
       border-left-color: #b0b0b0;
       border-right-color: #bbbbbb;
       background: white image_url("admin/search.png") 4px center no-repeat;
-      @include single-box-shadow(rgba(black, 0.2), 0, 1px, 0, inset);
+      box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.2);
       width: 180px;
       padding: 2px 8px 2px 20px;
     }
@@ -116,16 +121,16 @@ ul#secondary_navigation {
       height: 38px;
       text-decoration: none;
       &:hover {
-        @include linear-gradient(color-stops(#e4f9ff, #d2ebfd 30%, #b1d1f1 50%, #9bc5ed 50%, #caecff));
+        background-image: linear-gradient(to bottom, #e4f9ff, #d2ebfd 30%, #b1d1f1 50%, #9bc5ed 50%, #caecff);
         color: #444444;
       }
       &.current {
         background: #dddddd;
-        @include linear-gradient(color-stops(white, darken(white, 10%) 35%, darken(white, 15%) 50%, darken(white, 20%) 50%, darken(white, 15%)));
+        background-image: linear-gradient(to bottom, #ffffff, #e6e6e6 35%, #d9d9d9 50%, #cccccc 50%, #d9d9d9);
         color: #333333;
         font-weight: bold;
         &:hover {
-          @include linear-gradient(color-stops(#e0f9fe, #c4e2f8 30%, #98c3e7 50%, #79aedb 50%, #b1ddef));
+          background-image: linear-gradient(to bottom, #e0f9fe, #c4e2f8 30%, #98c3e7 50%, #79aedb 50%, #b1ddef);
           color: #222222;
         }
       }

--- a/app/assets/stylesheets/admin/partials/_index.scss
+++ b/app/assets/stylesheets/admin/partials/_index.scss
@@ -5,7 +5,7 @@
   padding: 0 6px;
   width: $width;
   text-align: center;
-  @include border-radius(100px);
+  border-radius: 100px;
 }
 
 table.index {
@@ -48,18 +48,20 @@ table.index {
       text-decoration: none;
       &:hover {
         background: #d8d8d8;
-        @include linear-gradient(color-stops(white, #cccccc));
+        background-image: linear-gradient(to bottom, #ffffff, #cccccc);
         border: 1px solid #a5c9df;
         margin: 0 24px 0 0;
-        @include border-radius;
+        border-radius: 5px;
       }
       &.selected {
         background: #c5e0f5;
-        @include linear-gradient(color_stops(#e5f5ff, #c5e0ff));
+        background-image: linear-gradient(to bottom, #e5f5ff, #c5e0ff);
         border: 1px solid #a5c9df;
         margin: 0 24px 0 0;
-        @include border-top-radius;
-        @include border-bottom-radius(0);
+        border-top-left-radius: 5px;
+        border-top-right-radius:: 5px;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius:: 0;
       }
     }
     span.action.disabled {
@@ -102,7 +104,7 @@ table.index {
         border-top: 1px solid #d5f0ff;
         border-bottom: 1px solid #c5dff5;
         background: #c5dff5;
-        @include linear-gradient(color_stops(#e5f5ff, #c5dff5));
+        background-image: linear-gradient(to bottom, #e5f5ff, #c5dff5);
       }
     }
   }

--- a/app/assets/stylesheets/admin/partials/_popup.scss
+++ b/app/assets/stylesheets/admin/partials/_popup.scss
@@ -16,7 +16,7 @@ div.popup {
   }
   .popup_title {
     background: #c5dff5;
-    @include linear-gradient(color_stops(#e5f5ff, #c5dff5));
+    background-image: linear-gradient(to bottom, #e5f5ff, #c5dff5);
     border-bottom: 1px solid #a7cdf0;
     font-weight: bold;
     font-size: 100%;
@@ -45,7 +45,7 @@ div.popup {
     border: 1px solid #dddddd;
     border-top: 1px solid #cccccc;
     border-left: 1px solid #cccccc;
-    @include single-box-shadow(white, 1px, 1px, 0);
+    box-shadow: 1px 1px 0 white;
     margin: 1em 0;
     overflow: auto;
     table.index {
@@ -61,18 +61,18 @@ div.popup {
     button {
       &.default {
         border: 1px solid #154ca6;
-        @include single-box-shadow(#c7e0f6, 0, 2px, 1px, inset);
+        box-shadow: inset 0 2px 1px #c7e0f6;
         color: white;
-        @include linear-gradient(color-stops(#67b4e1, #78b9e1));
+        background-image: linear-gradient(to bottom, #67b4e1, #78b9e1);
       }
       &:active {
         border: 1px solid #888888;
-        @include single-box-shadow(none);
-        @include linear-gradient(color-stops(#cccccc 0%, #dddddd 15%, #eeeeee 100%));
+        box-shadow: none;
+        background-image: linear-gradient(to bottom, #cccccc 0%, #dddddd 15%, #eeeeee 100%);
       }
       &.default:active {
         border: 1px solid #002c86;
-        @include linear-gradient(color-stops(#4794c1, #78b9e1));
+        background-image: linear-gradient(to bottom, #4794c1, #78b9e1);
       }
       &:focus {
         border-width: 2px;
@@ -227,13 +227,13 @@ div.popup.textured {
     padding: 10px 20px;
     margin: -20px -20px 20px;
     border-bottom: 1px solid #cccccc;
-    @include single-box-shadow(white, 0, 1px, 0);
+    box-shadow: 0 1px 0 white;
   }
   .buttons {
     border-top: 1px solid white;
     margin: 20px -20px -10px;
     padding: 20px;
-    @include single-box-shadow(#cccccc, 0, -1px, 0);
+    box-shadow: 0 -1px 0 #ccc;
   }
 }
 

--- a/app/assets/stylesheets/admin/partials/_tabcontrol.scss
+++ b/app/assets/stylesheets/admin/partials/_tabcontrol.scss
@@ -15,7 +15,8 @@
       padding: 8px 15px 5px;
       text-decoration: none;
       text-transform: titlecase;
-      @include border-top-radius(6px);
+      border-top-left-radius: 6px;
+      border-top-right-radius:: 6px;
       &.here {
         background-color: white;
         color: #737272;
@@ -37,8 +38,8 @@
     clear: both;
     .page {
       background: white;
-      @include linear-gradient(color-stops(white, #f5f1e2 15%, #f5f1e2));
-      @include single-box-shadow(rgba(0, 0, 0, 0.15), 2px, 2px, 3px);
+      background-image: linear-gradient(to bottom, #ffffff, #f5f1e2 15%, #f5f1e2);
+      box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.15);
       padding: 12px 20px 20px;
       p {
         margin-top: 0;

--- a/app/assets/stylesheets/admin/partials/_validations.scss
+++ b/app/assets/stylesheets/admin/partials/_validations.scss
@@ -11,8 +11,8 @@
     padding: 3px 6px;
     margin: 0 0 0 6px;
     background-color: #b30000;
-    @include border-radius;
-    @include single-box-shadow;
+    border-radius: 5px;
+    box-shadow: 0 5px #333;
     a.closer {
       margin-left: 10px;
       color: #ffcccc;

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,6 @@ require 'configuration_extensions/configuration_extensions'
 require 'radius'
 require 'trusty_cms/extension_loader'
 require 'trusty_cms/initializer'
-require 'compass'
 require 'rack/cache'
 require 'trustygems'
 
@@ -21,7 +20,6 @@ module TrustyCms
     config.active_record.whitelist_attributes = true
     config.autoload_paths += %W(#{config.root}/lib)
     config.eager_load_paths << Rails.root.join('lib')
-    Sass.load_paths << Compass::Frameworks['compass'].stylesheets_directory
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/lib/generators/instance/templates/instance_gemfile
+++ b/lib/generators/instance/templates/instance_gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 # If new versions of your installed gems are available, run `bundle update`
 
 gem "radiant", "~> <%= radiant_version %>"
-gem "compass-rails", "~> 1.0.3"
 
 # alternatively, in development
 # gem "trusty_cms", :path => "/path/to/trusty_cms/root"
@@ -32,8 +31,6 @@ gem "compass-rails", "~> 1.0.3"
 # SQL Server
 <%= '# ' unless db == 'sqlserver' %>gem "tiny_tds"
 <%= '# ' unless db == 'sqlserver' %>gem "activerecord-sqlserver-adapter", "~> 3.1.0"
-
-gem "compass-rails", "~> 1.0.3"
 
 # Default Extensions
 gem "radiant-archive-extension",             "~> 1.0.7"

--- a/lib/generators/trusty_cms/templates/application.rb.erb
+++ b/lib/generators/trusty_cms/templates/application.rb.erb
@@ -10,7 +10,6 @@ require 'trusty_cms/initializer'
 require 'string_extensions/string_extensions'
 require 'active_record_extensions/active_record_extensions'
 require 'configuration_extensions/configuration_extensions'
-require 'compass'
 require 'rack/cache'
 
 if defined?(Bundler)
@@ -28,8 +27,6 @@ module TrustyCms
     include TrustyCms::Initializer
 
     config.autoload_paths += %W(#{TRUSTY_CMS_ROOT}/lib)
-
-    Sass.load_paths << Compass::Frameworks['compass'].stylesheets_directory
 
     # Initialize extension paths
     config.initialize_extension_paths

--- a/lib/generators/trusty_cms/templates/compass.rb.erb
+++ b/lib/generators/trusty_cms/templates/compass.rb.erb
@@ -1,1 +1,0 @@
-additional_import_paths = ["app/assets/stylesheets/", "app/assets/stylesheets/admin"]

--- a/lib/generators/trusty_cms/trusty_cms_generator.rb
+++ b/lib/generators/trusty_cms/trusty_cms_generator.rb
@@ -10,7 +10,6 @@ class TrustyCmsGenerator < Rails::Generators::Base
     template "boot.rb.erb", "config/boot.rb"
     template "environment.rb.erb", "config/environment.rb"
     template "application.rb.erb", "config/application.rb"
-    template "compass.rb.erb", "config/compass.rb"
     template "preinitializer.rb.erb", "config/preinitializer.rb"
     template "routes.rb.erb", "config/routes.rb"
     template "database.yml.erb", "config/database.yml"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -10,7 +10,6 @@ require 'trusty_cms/initializer'
 require 'string_extensions/string_extensions'
 require 'active_record_extensions/active_record_extensions'
 require 'configuration_extensions/configuration_extensions'
-require 'compass'
 require 'rack/cache'
 require "sass-rails"
 
@@ -29,8 +28,6 @@ module TrustyCms
     config.autoload_paths += %W(#{TRUSTY_CMS_ROOT}/lib)
     config.autoload_paths += %W(#{config.root}/lib)
     config.autoload_paths += %W(#{config.root}/app/helpers)
-
-    Sass.load_paths << Compass::Frameworks['compass'].stylesheets_directory
 
     # Initialize extension paths
     config.initialize_extension_paths

--- a/trusty_cms.gemspec
+++ b/trusty_cms.gemspec
@@ -27,7 +27,6 @@ a general purpose content managment system--not merely a blogging engine.}
   s.add_dependency 'acts_as_tree',    '>= 2.6.1', '< 2.9.0'
   s.add_dependency 'bundler',         '~> 1.7'
   s.add_dependency 'ckeditor',        '>= 4.2.2', '< 4.4.0'
-  s.add_dependency 'compass-rails',   '>= 3.0.2', '< 3.2.0'
   s.add_dependency 'delocalize',      '>= 0.2', '< 2.0'
   s.add_dependency 'execjs',          '~> 2.7'
   s.add_dependency 'haml',            '~> 5.0'


### PR DESCRIPTION
Compass is no longer actively maintained: https://github.com/Compass/compass

---

Most of these changes are swapping a Compass mixin for vanilla CSS, because the mixin is no longer needed. For example, the `border-radius` mixin is used to output vendor prefixes, but `border-radius` is [well-supported these days](https://caniuse.com/#feat=border-radius).

**I was not able to run any test suite locally, so these changes are currently un-tested.**