### PR TITLE
Add in sass-rails as a dependency, eager load homepage when site is detected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ PATH
       rake (< 13.0)
       rdoc (>= 5.1, < 7.0)
       roadie-rails
+      sass-rails
       stringex (>= 2.7.1, < 2.9.0)
       therubyracer (~> 0.12.3)
       tzinfo (~> 1.2.3)
@@ -100,7 +101,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.4)
     crass (1.0.4)
-    css_parser (1.6.0)
+    css_parser (1.7.0)
       addressable
     database_cleaner (1.7.0)
     delocalize (1.2.0)
@@ -133,7 +134,7 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    httparty (0.16.3)
+    httparty (0.16.4)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     i18n (1.4.0)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -16,7 +16,7 @@ class Site < ActiveRecord::Base
 
     def find_for_host(hostname = '')
       return default if hostname.blank?
-      sites = where("domain IS NOT NULL")
+      sites = self.includes(:homepage).where("domain IS NOT NULL")
       site = sites.find { |site| hostname == site.base_domain || hostname =~ Regexp.compile(site.domain) }
       site || default
     end

--- a/trusty_cms.gemspec
+++ b/trusty_cms.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = ["TrustyCms CMS dev team"]
-  s.default_executable = %q{trusty_cms}
   s.description = %q{TrustyCms is a simple and powerful publishing system designed for small teams.
 It is built with Rails and is similar to Textpattern or MovableType, but is
 a general purpose content managment system--not merely a blogging engine.}
@@ -43,6 +42,7 @@ a general purpose content managment system--not merely a blogging engine.}
   s.add_dependency 'RedCloth',        '4.3.2'
   s.add_dependency 'rake',            '< 13.0'
   s.add_dependency 'roadie-rails'
+  s.add_dependency 'sass-rails'
   s.add_dependency 'stringex',        '>= 2.7.1', '< 2.9.0'
   s.add_dependency 'therubyracer',    '~> 0.12.3'
   s.add_dependency 'tzinfo',          '~> 1.2.3'


### PR DESCRIPTION
- Per the bullet gem, removed the N+1 query that was being executed when loading a homepage after locating a site
- Add in sass-rails as a holdover for removing compass 