### PR TITLE
Rapid 7 Security Updates: Round 1

### DIFF
--- a/app/controllers/admin/password_resets_controller.rb
+++ b/app/controllers/admin/password_resets_controller.rb
@@ -4,12 +4,9 @@ class Admin::PasswordResetsController < ApplicationController
 
   def create
     user = User.find_by_email(params[:email])
-    if user
-      user.send_password_reset
-      redirect_to welcome_path, :notice => "Email sent with password reset instructions."
-    else
-      redirect_to welcome_path, :notice => "Email not registered. Double check your spelling or seek out your Admin."
-    end
+    user.send_password_reset if user
+    redirect_to welcome_path, :notice => "If the e-mail address you entered is associated with a customer account in our records, you will receive an e-mail from us with instructions for resetting your password.
+    If you don't receive this e-mail, please check your junk mail folder or speak with your TrustyCMS administrator."
   end
 
   def edit
@@ -32,5 +29,4 @@ private
   def password_params
     params.require(:user).permit(:password, :password_confirmation)
   end
-
 end

--- a/app/views/admin/password_resets/new.html.haml
+++ b/app/views/admin/password_resets/new.html.haml
@@ -10,9 +10,3 @@
       = text_field_tag :email, params[:email], :class => 'textbox', :maxlength => 70, :size => 70
     .actions
       = submit_tag "Reset Password"
-
-  %p.version
-  = t('powered_by')
-  %a{ :href => "https://github.com/pgharts/trusty-cms" } TrustyCms CMS
-  = t('version')
-  = TrustyCms.loaded_via_gem? ? "#{TrustyCms::VERSION} (gem)." : "#{TrustyCms::VERSION}."

--- a/app/views/admin/welcome/login.html.haml
+++ b/app/views/admin/welcome/login.html.haml
@@ -16,9 +16,3 @@
       %label.checkbox{:for=>"remember_me"}= t('remember_me_in_this_browser')
     .buttons
       %input.button{:type => "submit", :value => t('login')}
-
-%p.version
-  = t('powered_by')
-  %a{ :href => "https://github.com/pgharts/trusty-cms" } TrustyCms CMS
-  = t('version')
-  = TrustyCms.loaded_via_gem? ? "#{TrustyCms::VERSION} (gem)." : "#{TrustyCms::VERSION}."


### PR DESCRIPTION
* Remove Powered by TrustyCMS
* Make the forgot password message more generic and helpful -- whether they are an user or not