### PR TITLE
Ruby 3 Upgrade - Update to URI.open

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (4.3.1)
+    trusty-cms (4.3.2)
       RedCloth (= 4.3.2)
       acts_as_list (>= 0.9.5, < 1.1.0)
       acts_as_tree (~> 2.9.1)

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -68,7 +68,7 @@ class Admin::AssetsController < Admin::ResourceController
 
   def compress(uploaded_asset)
     data = $kraken.upload(uploaded_asset.tempfile.path, 'lossy' => true)
-    File.write(uploaded_asset.tempfile, open(data.kraked_url).read, { mode: 'wb' })
+    File.write(uploaded_asset.tempfile, URI.open(data.kraked_url).read, mode: 'wb')
     uploaded_asset
   end
 

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '4.3.1'.freeze
+    VERSION = '4.3.2'.freeze
   end
 end


### PR DESCRIPTION
Mode no longer needs to be a hash and File.write needs to use URI.open 