### PR TITLE
Change trusty-cms manifest to engine-name-manifest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (4.3.2)
+    trusty-cms (4.3.3)
       RedCloth (= 4.3.2)
       acts_as_list (>= 0.9.5, < 1.1.0)
       acts_as_tree (~> 2.9.1)
@@ -117,7 +117,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
-    css_parser (1.9.0)
+    css_parser (1.10.0)
       addressable
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
@@ -144,9 +144,9 @@ GEM
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     ffi (1.15.3)
-    globalid (0.4.2)
-      activesupport (>= 4.2.0)
-    haml (5.2.1)
+    globalid (0.5.1)
+      activesupport (>= 5.0)
+    haml (5.2.2)
       temple (>= 0.8.0)
       tilt
     haml-rails (2.0.1)

--- a/app/assets/config/trusty-cms-manifest.js
+++ b/app/assets/config/trusty-cms-manifest.js
@@ -1,0 +1,6 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+//= link admin/assets.css
+//= link admin/assets_admin.js
+//= link admin/custom_file_upload.js

--- a/app/assets/config/trusty-cms/manifest.js
+++ b/app/assets/config/trusty-cms/manifest.js
@@ -1,7 +1,0 @@
-//= link_tree ../../images
-//= link_directory ../../javascripts .js
-//= link_directory ../../stylesheets .css
-//= link admin/assets.css
-//= link admin/assets_admin.js
-//= link admin/assets_admin.js
-//= link admin/custom_file_upload.js

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '4.3.2'.freeze
+    VERSION = '4.3.3'.freeze
   end
 end


### PR DESCRIPTION
Going forward - if the rails app using this engine is using precompiled assets - they will need to add trusty-cms-manifest.js to the config/initializers/assets.rb under precompile. 