### PR TITLE
Bump gem version -> 5.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (5.0.5)
+    trusty-cms (5.0.6)
       RedCloth (= 4.3.2)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.1.0)

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '5.0.5'.freeze
+    VERSION = '5.0.6'.freeze
   end
 end


### PR DESCRIPTION
Adds haml-lint config and bumps `rspec-rails` 5.0.2 -> 5.1.0