### PR TITLE
BugzID: 7382 - Review TODOs in lib/

### DIFF
--- a/lib/generators/instance/templates/instance_environment.rb
+++ b/lib/generators/instance/templates/instance_environment.rb
@@ -59,8 +59,7 @@ TrustyCms::Initializer.run do |config|
                         :verbose => false,
                         :allow_reload => false,
                         :allow_revalidate => false
-  # TODO: There's got to be a better place for this, but in order for assets to work fornow, we need ConditionalGet
-  # TODO: Workaround from: https://github.com/rtomayko/rack-cache/issues/80
+
   config.middleware.insert_before(Rack::ConditionalGet, Rack::Cache)
   config.assets.enabled = true
 

--- a/lib/generators/trusty_cms/templates/application.rb.erb
+++ b/lib/generators/trusty_cms/templates/application.rb.erb
@@ -86,7 +86,6 @@ module TrustyCms
     #    radiant: since this will enable manual expiration and acceleration headers.
 
 
-    # TODO: We're not sure this is actually working, but we can't really test this until the app initializes.
     config.middleware.use Rack::Cache,
                           :private_headers => ['Authorization'],
                           :entitystore => "radiant:tmp/cache/entity",
@@ -94,8 +93,7 @@ module TrustyCms
                           :verbose => false,
                           :allow_reload => false,
                           :allow_revalidate => false
-    # TODO: There's got to be a better place for this, but in order for assets to work fornow, we need ConditionalGet
-    # TODO: Workaround from: https://github.com/rtomayko/rack-cache/issues/80
+
     config.middleware.insert_before(Rack::ConditionalGet, Rack::Cache)
     config.assets.enabled = true
 


### PR DESCRIPTION
These TODOs are from pretty far back, but they seem to mirror a configuration that we're using throughout our app, in which:
- Middleware for Rack::Cache is configured
- an `insert_before` call is used to have Rack::ConditionalGet fire before Rack::Cache.

This same configuration is also used in CD and Festivity's application.rb, so unless this is causing a specific issue, I think these are fine to leave as they are.