### PR TITLE
BugzID: 7423 - Add last_sign_in to users table in admin

### DIFF
--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -13,6 +13,8 @@
             %th.roles= t('roles')
           - thead.actions_header do
             %th.actions{:style=>'width:9em'}= t('modify')
+          - thead.last_sign_in_at_header do
+            %th.last_sign_in_at= "Last Sign In"
     %tbody
       - @users.each do |user|
         %tr[user]
@@ -32,6 +34,11 @@
                   = link_to remove_admin_user_url(user), :class => 'action' do
                     %i.fas.fa-minus-circle
                     = t('remove')
+            - tbody.last_sign_in_at_cell do
+              -if user.last_sign_in_at.present?
+                %td.last_sign_in_at= user.last_sign_in_at.to_date
+              - else
+                %td.last_sign_in_at
 
 - render_region :bottom do |bottom|
   - bottom.new_button do

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '5.3.8'.freeze
+    VERSION = '5.3.9'.freeze
   end
 end

--- a/lib/trusty_cms/admin_ui.rb
+++ b/lib/trusty_cms/admin_ui.rb
@@ -196,8 +196,8 @@ module TrustyCms
           edit.form_bottom.concat %w{edit_buttons edit_timestamp}
         end
         user.index = RegionSet.new do |index|
-          index.thead.concat %w{title_header roles_header actions_header}
-          index.tbody.concat %w{title_cell roles_cell actions_cell}
+          index.thead.concat %w{title_header roles_header actions_header last_sign_in_at_header}
+          index.tbody.concat %w{title_cell roles_cell actions_cell last_sign_in_at_cell}
           index.bottom.concat %w{new_button}
         end
         user.new = user.edit


### PR DESCRIPTION
This pr uses Devise's Trackable module to list the last signed in date for the users in TrustyCMS. This is a first step towards building a system to alert us if a user has not used the CMS in some time to determine if we need to remove their access to it.