### PR TITLE
BugzID: 7442 - Remove broken render call to avatar

### DIFF
--- a/app/views/admin/preferences/edit.html.haml
+++ b/app/views/admin/preferences/edit.html.haml
@@ -8,7 +8,6 @@
   - main.edit_form do
     = form_for @user, :url => admin_preferences_path, :html => { :method => :put, 'data-onsubmit_status' => "#{t('saving_preferences')}&#8230;" } do |f|
       %fieldset
-        = render :partial => 'admin/users/avatar'
 
         = render_region :form_top, :locals => {:f => f}
 

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '5.3.8'.freeze
+    VERSION = '5.4.0'.freeze
   end
 end


### PR DESCRIPTION
This pr fixes the broken admin/preferences resource by removing a render call for the avatar partial that was deleted in an earlier version.