### PR TITLE
BugzID: 7499 - Quiet deprecation warning in Sidekiq

### DIFF
--- a/config/initializers/trusty_cms_config.rb
+++ b/config/initializers/trusty_cms_config.rb
@@ -1,94 +1,95 @@
 require 'multi_site/engine'
 require 'clipped/engine'
+Rails.application.reloader.to_prepare do
+  TrustyCms.config do |config|
+    config.define 'admin.title', default: 'TrustyCms CMS'
+    config.define 'dev.host'
+    config.define 'local.timezone', allow_change: true, select_from: lambda { ActiveSupport::TimeZone::MAPPING.keys.sort }
+    config.define 'defaults.locale', select_from: lambda { TrustyCms::AvailableLocales.locales }, allow_blank: true
+    config.define 'defaults.page.parts', default: 'Body,Extended'
+    config.define 'defaults.page.status', select_from: lambda { Status.selectable_values }, allow_blank: false, default: 'Draft'
+    config.define 'defaults.page.filter', select_from: lambda { TextFilter.descendants.map { |s| s.filter_name }.sort }, allow_blank: true
+    config.define 'defaults.page.fields'
+    config.define 'pagination.param_name', default: 'page'
+    config.define 'pagination.per_page_param_name', default: 'per_page'
+    config.define 'admin.pagination.per_page', type: :integer, default: 50
+    config.define 'site.title', default: 'Your site title', allow_blank: false
+    config.define 'site.host', default: 'www.example.com', allow_blank: false
+    config.define 'user.allow_password_reset?', default: true
+    config.define 'session_timeout', default: 2.weeks
+    require 'multi_site/scoped_validation'
+  end
 
-TrustyCms.config do |config|
-  config.define 'admin.title', default: 'TrustyCms CMS'
-  config.define 'dev.host'
-  config.define 'local.timezone', allow_change: true, select_from: lambda { ActiveSupport::TimeZone::MAPPING.keys.sort }
-  config.define 'defaults.locale', select_from: lambda { TrustyCms::AvailableLocales.locales }, allow_blank: true
-  config.define 'defaults.page.parts', default: 'Body,Extended'
-  config.define 'defaults.page.status', select_from: lambda { Status.selectable_values }, allow_blank: false, default: 'Draft'
-  config.define 'defaults.page.filter', select_from: lambda { TextFilter.descendants.map { |s| s.filter_name }.sort }, allow_blank: true
-  config.define 'defaults.page.fields'
-  config.define 'pagination.param_name', default: 'page'
-  config.define 'pagination.per_page_param_name', default: 'per_page'
-  config.define 'admin.pagination.per_page', type: :integer, default: 50
-  config.define 'site.title', default: 'Your site title', allow_blank: false
-  config.define 'site.host', default: 'www.example.com', allow_blank: false
-  config.define 'user.allow_password_reset?', default: true
-  config.define 'session_timeout', default: 2.weeks
-  require 'multi_site/scoped_validation'
-end
+  TrustyCms.config do |config|
+    config.namespace 'paperclip' do |pc|
+      pc.define 'url',                      default: '/system/:attachment/:id/:style/:basename:no_original_style.:extension', allow_change: true
+      pc.define 'path',                     default: ':rails_root/public/system/:attachment/:id/:style/:basename:no_original_style.:extension', allow_change: true
+      pc.define 'skip_filetype_validation', default: true, type: :boolean
+      pc.define 'storage', default: 'filesystem',
+                           select_from: {
+                             'File System' => 'filesystem',
+                             'Amazon S3' => 'fog',
+                             'Google Storage' => 'fog',
+                             'Rackspace Cloud Files' => 'fog',
+                           },
+                           allow_blank: false,
+                           allow_display: false
 
-TrustyCms.config do |config|
-  config.namespace 'paperclip' do |pc|
-    pc.define 'url',                      default: '/system/:attachment/:id/:style/:basename:no_original_style.:extension', allow_change: true
-    pc.define 'path',                     default: ':rails_root/public/system/:attachment/:id/:style/:basename:no_original_style.:extension', allow_change: true
-    pc.define 'skip_filetype_validation', default: true, type: :boolean
-    pc.define 'storage', default: 'filesystem',
-                         select_from: {
-                           'File System' => 'filesystem',
-                           'Amazon S3' => 'fog',
-                           'Google Storage' => 'fog',
-                           'Rackspace Cloud Files' => 'fog',
-                         },
-                         allow_blank: false,
-                         allow_display: false
+      pc.namespace 'fog' do |fog|
+        fog.define 'provider', select_from: {
+          'Amazon S3' => 'AWS',
+          'Google Storage' => 'Google',
+          'Rackspace Cloud Files' => 'Rackspace',
+        }
+        fog.define 'directory'
+        fog.define 'public?', default: true
+        fog.define 'host'
+      end
 
-    pc.namespace 'fog' do |fog|
-      fog.define 'provider', select_from: {
-        'Amazon S3' => 'AWS',
-        'Google Storage' => 'Google',
-        'Rackspace Cloud Files' => 'Rackspace',
-      }
-      fog.define 'directory'
-      fog.define 'public?', default: true
-      fog.define 'host'
+      pc.namespace 'google_storage' do |gs|
+        gs.define 'access_key_id'
+        gs.define 'secret_access_key'
+      end
+
+      pc.namespace 'rackspace' do |rs|
+        rs.define 'username'
+        rs.define 'api_key'
+      end
+
+      pc.namespace 's3' do |s3|
+        s3.define 'key'
+        s3.define 'secret'
+        s3.define 'region', select_from: {
+          'Asia North East' => 'ap-northeast-1',
+          'Asia South East' => 'ap-southeast-1',
+          'EU West' => 'eu-west-1',
+          'US East' => 'us-east-1',
+          'US West' => 'us-west-1',
+        }
+      end
     end
 
-    pc.namespace 'google_storage' do |gs|
-      gs.define 'access_key_id'
-      gs.define 'secret_access_key'
-    end
+    config.namespace 'assets', allow_display: false do |assets|
+      assets.define 'create_image_thumbnails?', default: 'true'
+      assets.define 'create_video_thumbnails?', default: 'true'
+      assets.define 'create_pdf_thumbnails?', default: 'true'
 
-    pc.namespace 'rackspace' do |rs|
-      rs.define 'username'
-      rs.define 'api_key'
-    end
+      assets.namespace 'thumbnails' do |thumbs| # NB :icon and :thumbnail are already defined as fixed formats for use in the admin interface and can't be changed
+        thumbs.define 'image', default: 'normal:size=640x640>|small:size=320x320>'
+        thumbs.define 'video', default: 'normal:size=640x640>,format=jpg|small:size=320x320>,format=jpg'
+        thumbs.define 'pdf', default: 'normal:size=640x640>,format=jpg|small:size=320x320>,format=jpg'
+      end
 
-    pc.namespace 's3' do |s3|
-      s3.define 'key'
-      s3.define 'secret'
-      s3.define 'region', select_from: {
-        'Asia North East' => 'ap-northeast-1',
-        'Asia South East' => 'ap-southeast-1',
-        'EU West' => 'eu-west-1',
-        'US East' => 'us-east-1',
-        'US West' => 'us-west-1',
-      }
+      assets.define 'max_asset_size', default: 5, type: :integer, units: 'MB'
+      assets.define 'display_size', default: 'normal', allow_blank: true
+      assets.define 'insertion_size', default: 'normal', allow_blank: true
     end
   end
 
-  config.namespace 'assets', allow_display: false do |assets|
-    assets.define 'create_image_thumbnails?', default: 'true'
-    assets.define 'create_video_thumbnails?', default: 'true'
-    assets.define 'create_pdf_thumbnails?', default: 'true'
-
-    assets.namespace 'thumbnails' do |thumbs| # NB :icon and :thumbnail are already defined as fixed formats for use in the admin interface and can't be changed
-      thumbs.define 'image', default: 'normal:size=640x640>|small:size=320x320>'
-      thumbs.define 'video', default: 'normal:size=640x640>,format=jpg|small:size=320x320>,format=jpg'
-      thumbs.define 'pdf', default: 'normal:size=640x640>,format=jpg|small:size=320x320>,format=jpg'
-    end
-
-    assets.define 'max_asset_size', default: 5, type: :integer, units: 'MB'
-    assets.define 'display_size', default: 'normal', allow_blank: true
-    assets.define 'insertion_size', default: 'normal', allow_blank: true
+  if TrustyCms.config_definitions['defaults.snippet.filter'].nil?
+    TrustyCms.config.define 'defaults.snippet.filter', select_from: lambda { TextFilter.descendants.map { |s| s.filter_name }.sort }, allow_blank: true
   end
-end
 
-if TrustyCms.config_definitions['defaults.snippet.filter'].nil?
-  TrustyCms.config.define 'defaults.snippet.filter', select_from: lambda { TextFilter.descendants.map { |s| s.filter_name }.sort }, allow_blank: true
+  Admin::LayoutsController.send :helper, MultiSite::SiteChooserHelper
+  Admin::SnippetsController.send :helper, MultiSite::SiteChooserHelper
 end
-
-Admin::LayoutsController.send :helper, MultiSite::SiteChooserHelper
-Admin::SnippetsController.send :helper, MultiSite::SiteChooserHelper

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '5.5.3'.freeze
+    VERSION = '5.5.1'.freeze
   end
 end

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,6 +2,6 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '5.5'.freeze
+    VERSION = '5.5.2'.freeze
   end
 end


### PR DESCRIPTION
sidekiq has been giving warnings that the following constants are autloaded during initialization and that doing so is deprecated: `TrustyCms::Config, Admin, Admin::RegionsHelper, ApplicationHelper, ApplicationController, Admin::ResourceHelper, Admin::ResourceController, Admin::LayoutsHelper, Admin::LayoutsController, MultiSite::SiteChooserHelper, Admin::SnippetsController, ShareLayouts, ShareLayouts::Controllers, ShareLayouts::Controllers::ActionController, SiteHelper, SiteController, Extensions, Extensions::SiteControllerExtensions, TrustyCms::Taggable, StandardTags, DeprecatedTags, Page, PageAssetAssociations, MultiSite::PageExtensions, CulturaldistrictApp, ShoppingCartMustNotBeEmptyFilter, ShoppingCartMustBeEmptyFilter, CulturaldistrictApp::ApplicationControllerExtensions, Admin::AssetsHelper, Admin::AssetsController, and Extensions::PaperclippedExtensions`.
By wrapping the 'trusty_cms_config.rb initializer' in `Rails.application.reloader.to_prepare` I've been able to quiet about half of these. The rest, except for TrustyCms::Config, are removed from the list by performing a similar action in culturaldistrict.org.