### PR TITLE
BugzID: 7530 - Jenga: unless_url

### DIFF
--- a/lib/generators/language_extension/templates/available_tags.yml
+++ b/lib/generators/language_extension/templates/available_tags.yml
@@ -434,13 +434,6 @@
 
       <pre><code><r&#58;unless_self>...</r&#58;unless_self></code></pre>
 
-    unless_url:
-      The opposite of the @if_url@ tag.
-
-      *Usage&#58;*
-
-      <pre><code><r&#58;unless_url matches="regexp" [ignore_case="true|false"]>...</r&#58;unless_url></code></pre>
-
     url:
       Renders the @url@ attribute of the current page.
 


### PR DESCRIPTION
I can't find `unless_url` in StandardTags anywhere. It might have been deleted in an earlier jenga pr. This pr removes the description from AvailableTags.