### PR TITLE
TrustyCMS v6.0.1 - Name Inflection updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (6.0.0)
+    trusty-cms (6.0.1)
       RedCloth (= 4.3.2)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.2.0)

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,0 +1,7 @@
+Rails.autoloaders.each do |autoloader|
+  autoloader.inflector.inflect(
+    'clipped_admin_ui' => 'ClippedAdminUI',
+    'admin_ui' => 'AdminUI',
+  # Add more inflections as needed
+  )
+end

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,7 +2,7 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '6.0.0'.freeze
+    VERSION = '6.0.1'.freeze
   end
 end
 


### PR DESCRIPTION
Add zeitwerk name inflection updates so that apps loading the engine won't fail on extensions.