### PR TITLE
Turns out we need to cache TrustyCms::Config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (6.0.1)
+    trusty-cms (6.0.2)
       RedCloth (= 4.3.2)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.2.0)

--- a/app/models/trusty_cms/config.rb
+++ b/app/models/trusty_cms/config.rb
@@ -81,8 +81,7 @@ module TrustyCms
               TrustyCms::Config.initialize_cache
             end
             TrustyCms::Config.initialize_cache if TrustyCms::Config.stale_cache?
-            # Rails.cache.read('TrustyCms::Config')[key]
-            # TODO: Do we need this line?
+            Rails.cache.read('TrustyCms::Config')[key]
           end
         end
       end

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,7 +2,7 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '6.0.1'.freeze
+    VERSION = '6.0.2'.freeze
   end
 end
 


### PR DESCRIPTION
in order to pass variables through