### PR TITLE
Remove uuidtools in favor of self generated UUID

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (6.0.3)
+    trusty-cms (6.0.4)
       RedCloth (= 4.3.2)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.2.0)
@@ -28,7 +28,6 @@ PATH
       stringex (>= 2.7.1, < 2.9.0)
       tzinfo (>= 1.2.3, < 2.1.0)
       uglifier (>= 3.2, < 5.0)
-      uuidtools (>= 2.1.5, < 2.3.0)
       will_paginate (>= 3, < 5)
 
 GEM
@@ -341,7 +340,6 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    uuidtools (2.2.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket-driver (0.7.6)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -186,7 +186,7 @@ class Asset < ActiveRecord::Base
   end
 
   def assign_uuid
-    self.uuid = UUIDTools::UUID.timestamp_create.to_s unless uuid?
+    self.uuid = SecureRandom.uuid unless uuid?
   end
 
   class << self

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -2,6 +2,7 @@ Rails.autoloaders.each do |autoloader|
   autoloader.inflector.inflect(
     'clipped_admin_ui' => 'ClippedAdminUI',
     'admin_ui' => 'AdminUI',
+    'ostruct' => 'OpenStruct',
   # Add more inflections as needed
   )
 end

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,7 +2,7 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '6.0.3'.freeze
+    VERSION = '6.0.4'.freeze
   end
 end
 

--- a/trusty_cms.gemspec
+++ b/trusty_cms.gemspec
@@ -50,6 +50,5 @@ a general purpose content management system--not merely a blogging engine.'
   s.add_dependency 'stringex', '>= 2.7.1', '< 2.9.0'
   s.add_dependency 'tzinfo', '>= 1.2.3', '< 2.1.0'
   s.add_dependency 'uglifier', '>= 3.2', '< 5.0'
-  s.add_dependency 'uuidtools', '>= 2.1.5', '< 2.3.0'
   s.add_dependency 'will_paginate', '>= 3', '< 5'
 end

--- a/vendor/extensions/clipped-extension/lib/clipped/engine.rb
+++ b/vendor/extensions/clipped-extension/lib/clipped/engine.rb
@@ -1,5 +1,4 @@
 require 'acts_as_list'
-require 'uuidtools'
 require 'trusty_cms_clipped_extension/cloud'
 require 'active_storage/engine'
 require 'will_paginate/array'


### PR DESCRIPTION
No need to depend on an external gem to generate a UUID. A zeitwerk problem arose generating one from the gem.