### PR TITLE
Hide Site Chooser if user is scoped to site

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,10 @@ class User < ActiveRecord::Base
     content_editor
   end
 
+  def scoped?
+    site_id.present?
+  end
+
   def locale
     'en'
   end

--- a/app/views/admin/layouts/_site_chooser.html.haml
+++ b/app/views/admin/layouts/_site_chooser.html.haml
@@ -1,4 +1,4 @@
-- if current_user.admin? && defined?(Site) && defined?(controller) && controller.sited_model? && controller.template_name == 'index' && Site.several?
+- if current_user.admin? && !current_user.scoped? && defined?(Site) && defined?(controller) && controller.sited_model? && controller.template_name == 'index' && Site.several?
   .site_chooser
     %ul.nav
       %li


### PR DESCRIPTION
The user should not see the site chooser if they are only scoped to one site. Adds a scoped? method that returns true if there is a site id and false if no site id exists. 