### PR TITLE
#4858 - set cache?=true, cache_timeout

### DIFF
--- a/app/models/file_not_found_page.rb
+++ b/app/models/file_not_found_page.rb
@@ -1,6 +1,6 @@
 class FileNotFoundPage < Page
   def cache_timeout
-    24.hours
+    5.minutes
   end
 
   def allowed_children

--- a/app/models/file_not_found_page.rb
+++ b/app/models/file_not_found_page.rb
@@ -1,4 +1,9 @@
 class FileNotFoundPage < Page
+
+  def cache_timeout
+    24.hours
+  end
+
   def allowed_children
     []
   end
@@ -24,7 +29,5 @@ class FileNotFoundPage < Page
     404
   end
 
-  def cache?
-    false
-  end
+
 end

--- a/app/models/file_not_found_page.rb
+++ b/app/models/file_not_found_page.rb
@@ -1,5 +1,4 @@
 class FileNotFoundPage < Page
-
   def cache_timeout
     24.hours
   end
@@ -28,6 +27,4 @@ class FileNotFoundPage < Page
   def response_code
     404
   end
-
-
 end

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,7 +2,7 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '6.0.4'.freeze
+    VERSION = '6.0.5'.freeze
   end
 end
 


### PR DESCRIPTION
The FileNotFound page error was fixed (in which the status was returning a 200 rather than a 404), but the cache heads were being set to private. This pr changes the value of the override method `#cache?` from 'false' to 'true', and defines a cache_timeout method.