### PR TITLE
Fix assets breaking on pages/edit

### DIFF
--- a/app/assets/javascripts/admin/assets.js
+++ b/app/assets/javascripts/admin/assets.js
@@ -56,7 +56,7 @@ Assets = {
     assetFilterParameters: function () {
         var parameters = [];
         if ($('#filesearchforminput').val() !== '') {
-            parameters.push([ 'search', $('#filesearchforminput').val() ]);
+            parameters.push([ 'search[title_cont]', $('#filesearchforminput').val() ]);
         }
 
         if ($('#page_id').val() !== undefined) {
@@ -193,6 +193,15 @@ $(function () {
         }
     });
 
+    $('#filesearchforminput').keyup(function () {
+        clearTimeout($(this).data('timeout'));
+        var timeout = setTimeout(function () {
+            Assets.filterAssets();
+            Assets.attachEvents();
+        }, 500);
+        $(this).data('timeout', timeout);
+    });
+
     $("#attach_assets").click(function (e) {
         e.preventDefault();
         Popup.show('attach_asset');
@@ -201,6 +210,14 @@ $(function () {
             Popup.close();
             $('#attach_asset').hide();
         });
+    });
+
+    $('#filesearchforminput').keyup(function () {
+        clearTimeout($(this).data('timeout'));
+        var timeout = setTimeout(function () {
+            Assets.filterAssets();
+        }, 500);
+        $(this).data('timeout', timeout);
     });
 
     $("#upload_asset_link").click(function (e) {

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -8,7 +8,6 @@ class Admin::AssetsController < Admin::ResourceController
   def index
     assets = Asset.order('created_at DESC')
     @page = Page.find(params[:page_id]) if params[:page_id]
-
     @term = assets.ransack(params[:search] || '')
     assets = @term.result(distinct: true)
 

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -32,6 +32,13 @@ class Admin::PagesController < Admin::ResourceController
     response_for :new
   end
 
+  def edit
+    assets = Asset.order('created_at DESC')
+    @term = assets.ransack(params[:search] || '')
+    @term.result(distinct: true)
+    response_for :edit
+  end
+
   def preview
     render_preview
   rescue PreviewStop => e

--- a/app/views/admin/pages/_asset_popups.html.haml
+++ b/app/views/admin/pages/_asset_popups.html.haml
@@ -24,7 +24,7 @@
       .popup_title= t('clipped_extension.find_assets')
 
       .toolbar
-        = render :partial => 'admin/assets/search'
+        = render :partial => 'admin/assets/search', locals: { term: @term, page: @page }
 
       #assets_table.assets.viewport
         - assets = Asset.all.paginate(:per_page => 20, page: params[:p])

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,7 +2,7 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '6.1.0'.freeze
+    VERSION = '6.1.1'.freeze
   end
 end
 


### PR DESCRIPTION
- Push assets to the search partial from the asset popup << add ransack term ivar to the edit controller, and I needed to add an edit controller to introduce some functionality to it. 
- Reintroduce autocomplete using the ransack params - I realized that you can't search in the popup without it. Pressing enter just redirects to assets tab page. Not helpful. 
- Add a pause before the search starts on keyup to avoid mixups in search. I noticed that in testing this - if i was typing out my search sometimes what I type was out of order in the search action. For example, searching "Benedum" I would see

cache: [GET /admin/assets?search[title_cont]=bene&pp=50] miss
cache: [GET /admin/assets?search[title_cont]=benedum&pp=50] miss
cache: [GET /admin/assets?search[title_cont]=ben&pp=50] miss

...Causing the results to return all images using ben instead of benedum. Adding the pause should reduce that greatly if not entirely. 

