### PR TITLE
Fix ransack error on creating pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (6.1.1)
+    trusty-cms (6.1.2)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.2.0)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -27,6 +27,8 @@ class Admin::PagesController < Admin::ResourceController
   end
 
   def new
+    assets = Asset.order('created_at DESC')
+    @term = assets.ransack(params[:search] || '')
     @page = self.model = model_class.new_with_defaults(trusty_config)
     assign_page_attributes
     response_for :new

--- a/lib/trusty_cms.rb
+++ b/lib/trusty_cms.rb
@@ -2,7 +2,7 @@ TRUSTY_CMS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')) unle
 
 unless defined? TrustyCms::VERSION
   module TrustyCms
-    VERSION = '6.1.1'.freeze
+    VERSION = '6.1.2'.freeze
   end
 end
 


### PR DESCRIPTION
The pages controller didn't have access to the term object therefore it was falling over on creating a new page. When I added it, everything worked successfully. 