### PR TITLE
#5117 - Set page_title field length to 100

### DIFF
--- a/app/views/admin/pages/_fields.html.haml
+++ b/app/views/admin/pages/_fields.html.haml
@@ -8,7 +8,7 @@
   - form.edit_title do
     %p.title
       %label{:for=>'page_title'}= t('page_title')
-      = fields.text_field :title, :class => 'textbox', :required => true
+      = fields.text_field :title, :class => 'textbox', :required => true, :size => 100
   - form.edit_extended_metadata do
     .drawer
       .drawer_contents#attributes

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '6.2.0'.freeze
+  VERSION = '6.2.1'.freeze
 end


### PR DESCRIPTION
This pr increases the size of the 'Page Title' field in Trusty to accomodate > 50 characters via the in-line 'size' attribute.