### PR TITLE
v6.3: Update for full compatibility with zeitwerk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,9 @@
 version: 2.1
-orbs:
-  ruby: circleci/ruby@1.8.0
+
 jobs:
   build:
     docker:
-      - image: cimg/ruby:3.0.5-node
+      - image: cimg/ruby:3.3.1-node
         environment:
           - RAILS_ENV: test
           - CC_TEST_REPORTER_ID: 10e89622ddc764206e253cd07c5784f83178fe45550920e0eac8ab2e020e3e93
@@ -12,7 +11,6 @@ jobs:
         environment:
           - MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
           - MYSQL_DATABASE: trusty_cms_test
-    executor: ruby/default
     working_directory: ~/trusty-cms
     steps:
       - checkout
@@ -24,11 +22,6 @@ jobs:
       - run:
           name: Bundler
           command: gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
-      - run:
-          name: "Update Node.js and npm"
-          command: |
-            curl -sSL "https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v16.13.2-linux-x64/bin/node
-            curl -O -L https://www.npmjs.com/install.sh | sudo bash
       - run:
           name: Bundle Install
           command: bundle install --jobs=4 --retry=3 --path vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,6 +366,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (6.2.1)
+    trusty-cms (6.3)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -76,9 +76,10 @@ module TrustyCms
         html
       end
     end
-    config.after_initialize do
-      # extension_loader.load_extensions
-      # extension_loader.load_extension_initializers
+    config.to_prepare do
+      extension_loader.deactivate_extensions
+      extension_loader.load_extensions
+      extension_loader.load_extension_initializers
 
       extension_loader.activate_extensions # also calls initialize_views
       # config.add_controller_paths(extension_loader.paths(:controller))

--- a/lib/active_record_extensions/active_record_extensions.rb
+++ b/lib/active_record_extensions/active_record_extensions.rb
@@ -1,6 +1,5 @@
-require 'active_record'
-
 class ActiveRecord::Base
+
   def self.validates_path(*args)
     configuration = args.extract_options!
     validates_each(args, configuration) do |record, attr_name, value|

--- a/lib/active_record_extensions/active_record_extensions.rb
+++ b/lib/active_record_extensions/active_record_extensions.rb
@@ -1,5 +1,4 @@
 class ActiveRecord::Base
-
   def self.validates_path(*args)
     configuration = args.extract_options!
     validates_each(args, configuration) do |record, attr_name, value|

--- a/lib/trusty_cms/extension_loader.rb
+++ b/lib/trusty_cms/extension_loader.rb
@@ -65,7 +65,7 @@ module TrustyCms
     #
     def load_extensions
       configuration = TrustyCms::Application.config
-      @observer ||= DependenciesObserver.new(configuration).observe(::ActiveSupport::Dependencies)
+      # @observer ||= DependenciesObserver.new(configuration).observe(::ActiveSupport::Dependencies)
       self.extensions = configuration.enabled_extensions.map { |ext| load_extension(ext) }.compact
     end
 

--- a/lib/trusty_cms/initializer.rb
+++ b/lib/trusty_cms/initializer.rb
@@ -9,15 +9,6 @@ require 'trusty_cms/extension_loader'
 require 'string_extensions/string_extensions'
 require 'trusty_cms/engine'
 
-# This is a wild and probably terrible hack built to initialize extension engines.
-# I have no idea what the repercussions will be. Revisit later.
-Gem.loaded_specs.each_with_object([]) do |(gemname, gemspec), _found|
-  if gemname =~ /trusty-.*-extension$/
-    ep = TrustyCms::ExtensionLoader.record_path(gemspec.full_gem_path, gemname)
-    require "#{ep.name}/engine"
-  end
-end
-
 module TrustyCms
   module Initializer
     # Rails::Initializer is essentially a list of startup steps and we extend it here by:

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '6.2.1'.freeze
+  VERSION = '6.3'.freeze
 end
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../boot', __FILE__)
+require File.expand_path('boot', __dir__)
 
 require 'rails/all'
 require 'acts_as_tree'
@@ -11,37 +11,35 @@ require 'string_extensions/string_extensions'
 require 'active_record_extensions/active_record_extensions'
 require 'configuration_extensions/configuration_extensions'
 require 'rack/cache'
-require "sassc-rails"
+require 'sassc-rails'
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
-  require 'rake'
-  Bundler.require(*Rails.groups(:assets => %w(development test)))
+  # Bundler.require(*Rails.groups(:assets => %w(development test)))
   # If you want your assets lazily compiled in production, use this line
-  # Bundler.require(:default, :assets, Rails.env)
+  Bundler.require(:default, :assets, Rails.env)
 end
 
 module TrustyCms
   class Application < Rails::Application
     include TrustyCms::Initializer
 
+    config.autoloader = :zeitwerk
     config.autoload_paths += %W(#{TRUSTY_CMS_ROOT}/lib)
-    config.autoload_paths += %W(#{config.root}/lib)
-    config.autoload_paths += %W(#{config.root}/app/helpers)
-
+    # config.autoload_paths += %W(#{config.root}/lib)
+    # config.autoload_paths += %W(#{config.root}/app/helpers)
     # Initialize extension paths
     config.initialize_extension_paths
     extension_loader = ExtensionLoader.instance { |l| l.initializer = self }
-    extension_loader.paths(:load).reverse_each do |path, value|
+    extension_loader.paths(:load).reverse_each do |path, _value|
       config.autoload_paths.unshift path
       $LOAD_PATH.unshift path
     end
     # config.add_plugin_paths(extension_loader.paths(:plugin))
-    trusty_locale_paths = Dir[File.join(TRUSTY_CMS_ROOT, 'config', 'locales', '*.{rb,yml}')]
-    config.i18n.load_path = trusty_locale_paths + extension_loader.paths(:locale)
+    radiant_locale_paths = Dir[File.join(TRUSTY_CMS_ROOT, 'config', 'locales', '*.{rb,yml}')]
+    config.i18n.load_path = radiant_locale_paths + extension_loader.paths(:locale)
 
     config.encoding = 'utf-8'
-    config.time_zone = 'UTC'
     # Skip frameworks you're not going to use (only works if using vendor/rails).
     # To use Rails without a database, you must remove the Active Record framework
     # config.frameworks -= [ :action_mailer ]
@@ -53,8 +51,8 @@ module TrustyCms
     # An example of how to add extensions:
     # config.extensions = [ :snippets, :clipped, :layouts, :reorder, :multi_site, :rad_social]
 
-    config.extensions = []
-    config.extensions_migration_order = []
+    config.extensions = %i[snippets clipped layouts multi_site festivity custom_tags]
+    config.extensions_migration_order = %i[snippets clipped layouts multi_site festivity]
 
     # By default, only English translations are loaded. Remove any of these from
     # the list below if you'd like to provide any of the additional options
@@ -77,23 +75,27 @@ module TrustyCms
     #    Turns on X-Accel-Redirect support for nginx. You have to provide
     #    a path that corresponds to a virtual location in your webserver
     #    configuration.
-    #  :entitystore => "trusty:tmp/cache/entity"
+    #  :entitystore => "radiant:tmp/cache/entity"
     #    Sets the entity store type (preceding the colon) and storage
     #   location (following the colon, relative to Rails.root).
-    #    We recommend you use trusty: since this will enable manual expiration.
-    #  :metastore => "trusty:tmp/cache/meta"
+    #    We recommend you use radiant: since this will enable manual expiration.
+    #  :metastore => "radiant:tmp/cache/meta"
     #    Sets the meta store type and storage location.  We recommend you use
-    #    trusty: since this will enable manual expiration and acceleration headers.
+    #    radiant: since this will enable manual expiration and acceleration headers.
+
     config.middleware.use Rack::Cache,
-                          :private_headers => ['Authorization'],
-                          :entitystore => "trusty:tmp/cache/entity",
-                          :metastore => "trusty:tmp/cache/meta",
-                          :verbose => false,
-                          :allow_reload => false,
-                          :allow_revalidate => false
+                          private_headers: ['Authorization'],
+                          entitystore: 'radiant:tmp/cache/entity',
+                          metastore: 'radiant:tmp/cache/meta',
+                          verbose: false,
+                          allow_reload: false,
+                          allow_revalidate: false
     config.middleware.insert_before(Rack::ConditionalGet, Rack::Cache)
+    config.assets.version = '1.1'
     config.assets.enabled = true
-    config.filter_parameters += [:password, :password_confirmation]
+    # added in sprockets-rails 3.4.2 adds a hash to css urls causing ckeditor to fail loading icons. Set to false to override.
+    config.assets.resolve_assets_in_css_urls = false
+    config.filter_parameters += %i[password password_confirmation]
 
     # Use the database for sessions instead of the cookie-based default,
     # which shouldn't be used to store highly confidential information
@@ -101,15 +103,12 @@ module TrustyCms
     # config.action_controller.session_store = :cookie_store DEPRECATED
 
     # Activate observers that should always be running
-    # config.active_record.observers = :user_action_observer
+    config.active_record.observers = :user_action_observer
 
     # The internationalization framework can be changed to have another default locale (standard is :en) or more load paths.
     # All files from config/locales/*.rb,yml are added automatically.
     # config.i18n.load_path << Dir[File.join(Rails.root, 'my', 'locales', '*.{rb,yml}')]
     # config.i18n.default_locale = :'en'
-
-    # Make Active Record use UTC-base instead of local time
-    config.time_zone = 'UTC'
 
     # Set the default field error proc
     config.action_view.field_error_proc = Proc.new do |html, instance|
@@ -119,6 +118,10 @@ module TrustyCms
         html
       end
     end
+    # Make Active Record use UTC-base instead of local time
+    # config.time_zone = 'UTC'
+    config.time_zone = 'Eastern Time (US & Canada)'
+    # config.active_record.default_timezone = :local
 
     config.after_initialize do
       extension_loader.load_extensions
@@ -127,7 +130,6 @@ module TrustyCms
       # Dir["#{TRUSTY_CMS_ROOT}/config/initializers/**/*.rb"].sort.each do |initializer|
       #  load(initializer)
       # end
-
       extension_loader.activate_extensions # also calls initialize_views
       # config.add_controller_paths(extension_loader.paths(:controller))
       # config.add_eager_load_paths(extension_loader.paths(:eager_load))
@@ -136,7 +138,6 @@ module TrustyCms
       ActiveSupport::Inflector.inflections do |inflect|
         inflect.uncountable 'config'
       end
-
     end
   end
 end

--- a/vendor/extensions/layouts-extension/layouts_extension.rb
+++ b/vendor/extensions/layouts-extension/layouts_extension.rb
@@ -8,11 +8,11 @@ class LayoutsExtension < TrustyCms::Extension
     ActionView::Base.send :include, ShareLayouts::Helpers::ActionView
 
     # Nested Layouts
-    Page.send   :include, NestedLayouts::Tags::Core
+    Page.send :include, NestedLayouts::Tags::Core
 
     # HAML Layouts
-    Layout.send  :include, HamlLayouts::Models::Layout
-    Page.send    :include, HamlLayouts::Models::Page
+    Layout.send :include, HamlLayouts::Models::Layout
+    Page.send :include, HamlLayouts::Models::Page
     HamlFilter
   end
 

--- a/vendor/extensions/multi-site-extension/lib/multi_site/scoped_validation.rb
+++ b/vendor/extensions/multi-site-extension/lib/multi_site/scoped_validation.rb
@@ -1,43 +1,33 @@
 module MultiSite::ScopedValidation
+  # scoping validations to the site should be very simple
+  # all you would normally need is something like this:
+  #
+  #   validates_uniqueness_of :email, :scope => :site_id
+  #
+  # but if you want to scope core trusty classes, you have a problem:
+  # their uniqueness validations have already been declared
+  # The only answer is to reach right back and change the validates_uniqueness_of method
+  # and to make it more awkward, that has to happen so early that we can't reflect on the site association.
+  # Hence the check for a site_id column. It's a hack, but a fairly harmless one.
 
-  def self.included(base)
-
-    base.class_eval do
-      # scoping validations to the site should be very simple
-      # all you would normally need is something like this:
-      #
-      #   validates_uniqueness_of :email, :scope => :site_id
-      #
-      # but if you want to scope core trusty classes, you have a problem:
-      # their uniqueness validations have already been declared
-      # The only answer is to reach right back and change the validates_uniqueness_of method
-      # and to make it more awkward, that has to happen so early that we can't reflect on the site association.
-      # Hence the check for a site_id column. It's a hack, but a fairly harmless one.
-
-      def validates_uniqueness_of_with_site(*attr)
-        if database_exists?
-          if table_exists? && column_names.include?('site_id')
-            configuration = attr.extract_options!
-            configuration[:scope] ||= :site_id
-            attr.push(configuration)
-          end
-          validates_uniqueness_of_without_site(*attr)
-        end
+  def validates_uniqueness_of(*attr)
+    if database_exists?
+      if table_exists? && column_names.include?('site_id')
+        configuration = attr.extract_options!
+        configuration[:scope] ||= :site_id
+        attr.push(configuration)
       end
-
-      alias_method :validates_uniqueness_of_without_site, :validates_uniqueness_of
-      alias_method :validates_uniqueness_of, :validates_uniqueness_of_with_site
-
-      def database_exists?
-        ActiveRecord::Base.connection
-      rescue ActiveRecord::NoDatabaseError
-        false
-      else
-        true
-      end
+      super(*attr)
     end
+  end
 
+  def database_exists?
+    ActiveRecord::Base.connection
+  rescue ActiveRecord::NoDatabaseError
+    false
+  else
+    true
   end
 end
 
-ActiveRecord::Validations::ClassMethods.send :include, MultiSite::ScopedValidation
+ActiveRecord::Validations::ClassMethods.prepend MultiSite::ScopedValidation

--- a/vendor/extensions/multi-site-extension/multi_site_extension.rb
+++ b/vendor/extensions/multi-site-extension/multi_site_extension.rb
@@ -6,7 +6,6 @@ class MultiSiteExtension < TrustyCms::Extension
   url "http://trustarts.org/"
 
   def activate
-
     # Model extensions
     ActiveRecord::Base.send :include, MultiSite::ScopedModel
     Page.send :include, MultiSite::PageExtensions

--- a/vendor/extensions/snippets-extension/snippets_extension.rb
+++ b/vendor/extensions/snippets-extension/snippets_extension.rb
@@ -34,7 +34,7 @@ class SnippetsExtension < TrustyCms::Extension
       end
     end
 
-    admin.snippet       ||= TrustyCms::AdminUI.load_default_snippet_regions
+    admin.snippet ||= TrustyCms::AdminUI.load_default_snippet_regions
 
     tab 'Design' do
       add_item "Snippets", "/admin/snippets"


### PR DESCRIPTION
- Removes the gem loader for extensions as this has been deprecated for a while
- Rewrites the module MultiSite::ScopedValidation to use prepend methods as this was causing a stack error when making changes and reloading
- Comment out dependency observer. This should no longer be needed for zeitwerk should be autoloading extensions and dependencies. 
- Shows that in the new world, config.to_prepare should be utilized instead of after_initialize. This file makes no difference but when the engine is installed this configuration will be passed on to the app that is installing trusty-cms. The .to_prepare will direct the app to reload what is inside this block, so instead of using the dependency observer, the app will deactivate and reactive extensions inside this block instead.
- Register v6.3 on rubygems