### PR TITLE
TrustyCMS v 7.0.1 - Bug fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.0)
+    trusty-cms (7.0.1)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/assets/javascripts/admin/custom_file_upload.js
+++ b/app/assets/javascripts/admin/custom_file_upload.js
@@ -1,7 +1,7 @@
 $(function () {
-  var fileUpload = $('#asset_asset');
-  var fileChosen = $('#file-chosen');
-  fileUpload.on('change', function() {
-    fileChosen.text(this.files[0].name)
-  })
+    const fileUpload = $('#asset_asset');
+    const fileChosen = $('#file-chosen');
+    fileUpload.on('change', function () {
+        fileChosen.text(this.files[0].name)
+    })
 });

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -35,7 +35,7 @@ class Admin::AssetsController < Admin::ResourceController
     @assets = []
     @page_attachments = []
     compress = current_site.try(:compress).nil? ? true : current_site.compress
-    asset_params[:asset][:asset].to_a.each do |uploaded_asset|
+    asset_params[:asset][:asset].reject(&:blank?).each do |uploaded_asset|
       if uploaded_asset.content_type == 'application/octet-stream'
         flash[:notice] = 'Please only upload assets that have a valid extension in the name.'
       else
@@ -90,6 +90,6 @@ class Admin::AssetsController < Admin::ResourceController
   end
 
   def asset_params
-    params.permit(:id, :for_attachment, asset: [:caption, :for_attachment, asset: []])
+    params.permit(:id, :for_attachment, asset: [:for_attachment, { asset: [] }])
   end
 end

--- a/app/helpers/admin/references_helper.rb
+++ b/app/helpers/admin/references_helper.rb
@@ -5,7 +5,7 @@ module Admin::ReferencesHelper
     String.new.tap do |output|
       class_of_page.tag_descriptions.sort.each do |tag_name, description|
         value = t("desc.#{tag_name.gsub(':', '-')}").match('desc') ? description : t("desc.#{tag_name.gsub(':', '-')}")
-        output << render(partial: 'admin/references/tag_reference.haml',
+        output << render(partial: 'admin/references/tag_reference',
                          locals: { tag_name: tag_name,
                                    description: RedCloth.new(TrustyCms::Taggable::Util.strip_leading_whitespace(value)).to_html })
       end
@@ -35,8 +35,8 @@ module Admin::ReferencesHelper
 
   def filter
     @filter ||= begin
-      TextFilter.find_descendant(params[:filter_name])
-    end
+                  TextFilter.find_descendant(params[:filter_name])
+                end
   end
 
   def class_of_page

--- a/app/views/admin/assets/new.html.haml
+++ b/app/views/admin/assets/new.html.haml
@@ -8,7 +8,6 @@
 
     - main.edit_form do
       - form_for :asset, :url => admin_assets_path, :html => { :method => "post", :multipart => true } do |f|
-        = render :partial => "form", :locals => { :f => f }
         %fieldset
           %label.custom-file-upload
             = t("clipped_extension.choose_file")

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '7.0.0'.freeze
+  VERSION = '7.0.1'.freeze
 end
 


### PR DESCRIPTION
Resolves [#2049](https://github.com/pgharts/festivity-site/issues/2049) - The issue here is that the first "input" is blank, since it's a multipart uploader, causing a blank first entry in the array. Ended up adding a reject blank entries here to avoid this on the backend. 

Resolves [#2048](https://github.com/pgharts/festivity-site/issues/2048) - This was a simple 'remove the file extension from the render partial' and I checked the rest of the app and it doesn't seem that we do this anywhere else.

Deprecates the caption input - this is not rendering anywhere.
