### PR TITLE
Add better role support for users

### DIFF
--- a/app/controllers/admin/configuration_controller.rb
+++ b/app/controllers/admin/configuration_controller.rb
@@ -5,7 +5,7 @@ class Admin::ConfigurationController < ApplicationController
   # and the show and edit views determine what set of config values is shown and made editable.
 
   before_action :initialize_config
-
+  before_action :authorize_role
   only_allow_access_to :edit, :update,
                        when: [:admin],
                        denied_url: { controller: 'admin/configuration', action: 'show' },

--- a/app/controllers/admin/extensions_controller.rb
+++ b/app/controllers/admin/extensions_controller.rb
@@ -1,4 +1,5 @@
 class Admin::ExtensionsController < ApplicationController
+  before_action :authorize_role
   only_allow_access_to :index,
                        when: :admin,
                        denied_url: { controller: 'pages', action: 'index' },

--- a/app/controllers/admin/layouts_controller.rb
+++ b/app/controllers/admin/layouts_controller.rb
@@ -1,7 +1,7 @@
 class Admin::LayoutsController < Admin::ResourceController
   paginate_models
   only_allow_access_to :index, :show, :new, :create, :edit, :update, :remove, :destroy,
-                       when: %i[designer admin],
+                       when: %i[editor admin],
                        denied_url: { controller: 'admin/pages', action: 'index' },
-                       denied_message: 'You must have designer privileges to perform this action.'
+                       denied_message: 'You must have at least editor privileges to perform this action.'
 end

--- a/app/controllers/admin/layouts_controller.rb
+++ b/app/controllers/admin/layouts_controller.rb
@@ -1,7 +1,7 @@
 class Admin::LayoutsController < Admin::ResourceController
   paginate_models
   only_allow_access_to :index, :show, :new, :create, :edit, :update, :remove, :destroy,
-                       when: %i[editor admin],
+                       when: %i[designer admin],
                        denied_url: { controller: 'admin/pages', action: 'index' },
                        denied_message: 'You must have at least editor privileges to perform this action.'
 end

--- a/app/controllers/admin/layouts_controller.rb
+++ b/app/controllers/admin/layouts_controller.rb
@@ -1,5 +1,6 @@
 class Admin::LayoutsController < Admin::ResourceController
   paginate_models
+  before_action :authorize_role
   only_allow_access_to :index, :show, :new, :create, :edit, :update, :remove, :destroy,
                        when: %i[designer admin],
                        denied_url: { controller: 'admin/pages', action: 'index' },

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -1,5 +1,6 @@
 class Admin::SitesController < Admin::ResourceController
   helper :sites
+  before_action :authorize_role
   only_allow_access_to :index, :show, :new, :create, :edit, :update, :remove, :destroy,
                        when: :admin,
                        denied_url: { controller: 'pages', action: 'index' },

--- a/app/controllers/admin/snippets_controller.rb
+++ b/app/controllers/admin/snippets_controller.rb
@@ -1,5 +1,6 @@
 class Admin::SnippetsController < Admin::ResourceController
   paginate_models
+  before_action :authorize_role
   only_allow_access_to :index, :show, :new, :create, :edit, :update, :remove, :destroy,
                        when: %i[designer admin],
                        denied_url: { controller: 'admin/pages', action: 'index' },

--- a/app/controllers/admin/snippets_controller.rb
+++ b/app/controllers/admin/snippets_controller.rb
@@ -1,7 +1,7 @@
 class Admin::SnippetsController < Admin::ResourceController
   paginate_models
   only_allow_access_to :index, :show, :new, :create, :edit, :update, :remove, :destroy,
-                       when: %i[editor admin],
+                       when: %i[designer admin],
                        denied_url: { controller: 'admin/pages', action: 'index' },
                        denied_message: 'You must have at least editor privileges to perform this action.'
 end

--- a/app/controllers/admin/snippets_controller.rb
+++ b/app/controllers/admin/snippets_controller.rb
@@ -1,7 +1,7 @@
 class Admin::SnippetsController < Admin::ResourceController
   paginate_models
   only_allow_access_to :index, :show, :new, :create, :edit, :update, :remove, :destroy,
-                       when: %i[designer admin],
+                       when: %i[editor admin],
                        denied_url: { controller: 'admin/pages', action: 'index' },
-                       denied_message: 'You must have designer privileges to perform this action.'
+                       denied_message: 'You must have at least editor privileges to perform this action.'
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < Admin::ResourceController
   paginate_models
+  before_action :authorize_role
   only_allow_access_to :index, :show, :new, :create, :edit, :update, :remove, :destroy,
                        when: :admin,
                        denied_url: { controller: 'pages', action: 'index' },

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -3,6 +3,7 @@ module Admin::UsersHelper
     roles = []
     roles << I18n.t('admin') if user.admin?
     roles << I18n.t('editor') if user.editor?
+    roles << I18n.t('content_editor') if user.content_editor?
     roles.join(', ')
   end
 end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -2,7 +2,7 @@ module Admin::UsersHelper
   def roles(user)
     roles = []
     roles << I18n.t('admin') if user.admin?
-    roles << I18n.t('designer') if user.designer?
+    roles << I18n.t('editor') if user.editor?
     roles.join(', ')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   alias_attribute :created_by_id, :id
-
   attr_accessor :skip_password_validation
 
   validate :password_complexity
@@ -18,6 +17,10 @@ class User < ActiveRecord::Base
   # Associations
   belongs_to :created_by, class_name: 'User'
   belongs_to :updated_by, class_name: 'User'
+
+  # Roles
+  # Admin - all permissions
+  # Editor - all permissions except for users, sites editing
 
   def role?(role)
     case role
@@ -37,6 +40,10 @@ class User < ActiveRecord::Base
   end
 
   def designer?
+    designer
+  end
+
+  def editor?
     designer
   end
 
@@ -67,4 +74,6 @@ class User < ActiveRecord::Base
 
     errors.add :password, 'Complexity requirement not met. Length should be 12 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character.'
   end
+
+  alias editor? designer?
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,5 +76,4 @@ class User < ActiveRecord::Base
     errors.add :password, 'Complexity requirement not met. Length should be 12 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character.'
   end
 
-  alias editor? designer?
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ActiveRecord::Base
   # Roles
   # Admin - all permissions
   # Editor - all permissions except for users, sites editing
+  # Content Editor - all permissions except for users, sites, publishing and deleting
 
   def role?(role)
     case role

--- a/app/views/admin/layouts/_site_chooser.html.haml
+++ b/app/views/admin/layouts/_site_chooser.html.haml
@@ -1,4 +1,4 @@
-- if current_user.admin? && !current_user.scoped? && defined?(Site) && defined?(controller) && controller.sited_model? && controller.template_name == 'index' && Site.several?
+- if !current_user.scoped? && defined?(Site) && defined?(controller) && controller.sited_model? && controller.template_name == 'index' && Site.several?
   .site_chooser
     %ul.nav
       %li

--- a/app/views/admin/pages/_fields.html.haml
+++ b/app/views/admin/pages/_fields.html.haml
@@ -41,9 +41,10 @@
         = fields.label :class_name, t('page_type')
         = fields.select :class_name, [[t('select.normal'), '']] + Page.descendants.map { |p| [p.display_name, p.name] }.sort_by { |p| p.first }
     - layout.edit_status do
-      .status
-        = fields.label :status_id, t('status')
-        = fields.select :status_id, status_to_display
+      - if current_user.admin? || current_user.editor?
+        .status
+          = fields.label :status_id, t('status')
+          = fields.select :status_id, status_to_display
     - layout.edit_published_at do
       .published-date
         #published_at{:class => (@page.published? ? nil : 'hidden')}

--- a/app/views/admin/pages/_node.html.haml
+++ b/app/views/admin/pages/_node.html.haml
@@ -18,5 +18,5 @@
       - unless simple
         %td.actions
           = page.add_child_option
-          - if current_user.admin?
+          - if current_user.editor? || current_user.admin?
             = page.remove_option

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -26,6 +26,8 @@
           = f.label :admin, t('admin'), :class => 'checkbox'
           = f.check_box 'designer', :class => 'checkbox'
           = f.label :designer, t('editor'), :class => 'checkbox'
+          = f.check_box 'content_editor', :class => 'checkbox'
+          = f.label :content_editor, t('content_editor'), :class => 'checkbox'
 
     - form.edit_notes do
       %fieldset

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -25,7 +25,7 @@
           = f.check_box 'admin', :class => 'checkbox'
           = f.label :admin, t('admin'), :class => 'checkbox'
           = f.check_box 'designer', :class => 'checkbox'
-          = f.label :designer, t('designer'), :class => 'checkbox'
+          = f.label :designer, t('editor'), :class => 'checkbox'
 
     - form.edit_notes do
       %fieldset

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,7 @@ en:
         secret: 'Secret'
       skip_filetype_validation: 'Skip Filetype Validation'
       storage: 'Storage'
-      url: 'Url'  
+      url: 'Url'
     defaults:
       locale: 'default language'
       page:
@@ -161,15 +161,15 @@ en:
   content_type: 'Content&#8209;Type'
   creating_status: 'Creating %{model}&#8230;'
   date:
-    abbr_day_names: [Sun, Mon, Tue, Wed, Thu, Fri, Sat]
-    abbr_month_names: [~, Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec]
-    day_names: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
+    abbr_day_names: [ Sun, Mon, Tue, Wed, Thu, Fri, Sat ]
+    abbr_month_names: [ ~, Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec ]
+    day_names: [ Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday ]
     formats:
       default: "%Y-%m-%d"
       long: "%B %e, %Y"
       only_day: "%e"
       short: "%e %b"
-    month_names: [~, January, February, March, April, May, June, July, August, September, October, November, December]
+    month_names: [ ~, January, February, March, April, May, June, July, August, September, October, November, December ]
     order:
       - :year
       - :month
@@ -183,9 +183,10 @@ en:
   designer: 'Designer'
   draft: 'Draft'
   edit: 'Edit'
+  editor: 'Editor'
   edit_configuration: 'Edit Configuration'
   edit_layout: 'Edit Layout'
-  edit_page:  'Edit Page'
+  edit_page: 'Edit Page'
   edit_preferences: 'Edit Preferences'
   edit_settings: 'Edit Settings'
   edit_user: 'Edit User'
@@ -242,7 +243,7 @@ en:
   published: 'Published'
   published_at: 'Published at'
   published_on: 'Published On'
-  reference:  'Reference'
+  reference: 'Reference'
   remember_me: 'Remember me'
   remember_me_in_this_browser: 'Remember me in this browser'
   remove: 'Remove'
@@ -277,7 +278,7 @@ en:
   snippets: 'Snippets'
   snippet: 'Snippet'
   status: 'Status'
-    # Warnings and info text:
+  # Warnings and info text:
   testing: Testing
   text:
     layouts:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,7 @@ en:
       allow_password_reset?: "allow password reset"
   content: 'Content'
   content_type: 'Content&#8209;Type'
+  content_editor: 'Content Editor'
   creating_status: 'Creating %{model}&#8230;'
   date:
     abbr_day_names: [ Sun, Mon, Tue, Wed, Thu, Fri, Sat ]

--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -56,7 +56,7 @@ module LoginSystem
     permissions = self.class.controller_permissions[action]
     flash[:error] = permissions[:denied_message] || 'Access denied.'
     respond_to do |format|
-      format.html { redirect_to(permissions[:denied_url] || { :action => :index }) }
+      format.html { redirect_to(permissions[:denied_url] || { action: :index }) }
       format.any(:xml, :json) { head :forbidden }
     end
   end

--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -42,21 +42,23 @@ module LoginSystem
 
   def authorize_role
     action = action_name.to_s.intern
-    if user_has_access_to_action?(action)
-      true
-    else
-      permissions = self.class.controller_permissions[action]
-      flash[:error] = permissions[:denied_message] || 'Access denied.'
-      respond_to do |format|
-        format.html { redirect_to(permissions[:denied_url] || { :action => :index }) }
-        format.any(:xml, :json) { head :forbidden }
-      end
-      false
-    end
+    return true if user_has_access_to_action?(action)
+
+    handle_unauthorized_access
+    false
   end
 
   def user_has_access_to_action?(action)
     self.class.user_has_access_to_action?(current_user, action, self)
+  end
+
+  def handle_unauthorized_access
+    permissions = self.class.controller_permissions[action]
+    flash[:error] = permissions[:denied_message] || 'Access denied.'
+    respond_to do |format|
+      format.html { redirect_to(permissions[:denied_url] || { :action => :index }) }
+      format.any(:xml, :json) { head :forbidden }
+    end
   end
 
   def login_from_session

--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -2,7 +2,6 @@ module LoginSystem
   def self.included(base)
     base.extend ClassMethods
     base.class_eval do
-      prepend_before_action :authorize_role
       # prepend_before_action :authenticate
       # prepend_before_action :authorize
       # helper_method :current_user

--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -2,6 +2,7 @@ module LoginSystem
   def self.included(base)
     base.extend ClassMethods
     base.class_eval do
+      prepend_before_action :authorize_role
       # prepend_before_action :authenticate
       # prepend_before_action :authorize
       # helper_method :current_user
@@ -40,21 +41,19 @@ module LoginSystem
     true
   end
 
-  def authorize
-    # puts _process_action_callbacks.map(&:filter)
-    # action = action_name.to_s.intern
-    # if user_has_access_to_action?(action)
-    #   true
-    # else
-    #   permissions = self.class.controller_permissions[action]
-    #   flash[:error] = permissions[:denied_message] || 'Access denied.'
-    #   respond_to do |format|
-    #     format.html { redirect_to(permissions[:denied_url] || { :action => :index }) }
-    #     format.any(:xml, :json) { head :forbidden }
-    #   end
-    #   false
-    # end
-    true
+  def authorize_role
+    action = action_name.to_s.intern
+    if user_has_access_to_action?(action)
+      true
+    else
+      permissions = self.class.controller_permissions[action]
+      flash[:error] = permissions[:denied_message] || 'Access denied.'
+      respond_to do |format|
+        format.html { redirect_to(permissions[:denied_url] || { :action => :index }) }
+        format.any(:xml, :json) { head :forbidden }
+      end
+      false
+    end
   end
 
   def user_has_access_to_action?(action)

--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -44,7 +44,7 @@ module LoginSystem
     action = action_name.to_s.intern
     return true if user_has_access_to_action?(action)
 
-    handle_unauthorized_access
+    handle_unauthorized_access(action)
     false
   end
 
@@ -52,7 +52,7 @@ module LoginSystem
     self.class.user_has_access_to_action?(current_user, action, self)
   end
 
-  def handle_unauthorized_access
+  def handle_unauthorized_access(action)
     permissions = self.class.controller_permissions[action]
     flash[:error] = permissions[:denied_message] || 'Access denied.'
     respond_to do |format|


### PR DESCRIPTION
**Refactor:** Alias designer to editor, Add content editor Role, and Enhance Role-Based Validation
This PR includes several updates related to roles and permissions in the application:

### Roles Overview:

**Admin**: Full access to all permissions.
**Editor**: All permissions except user and site management.
**Content Editor**: All permissions except user management, site editing, publishing, and deleting content.

1. Renamed designer to editor:
    1. The `designer` role has been aliased to `editor` to better align with the role's purpose.
    2. Changes were implemented using `editor?` method for backward compatibility.

2. Added content editor Role:
    1. Introduced a new `content editor` role with specific permissions. This already existed in some ways but not properly implemented.

3. Backend Validation for Roles:

    1. Re-added server-side validation to restrict access to URLs based on role permissions. This was removed when devise was implemented.
    2. Unauthorized access now results in a proper error message and a redirect (see screenshots), ensuring better user experience and security. `before_action` was added because adding intervention when devise was authenticating was causing issues.

![Screenshot 2024-11-15 at 1 56 26 PM](https://github.com/user-attachments/assets/bb472046-0696-405d-910a-e0270e98d8d4)
![Screenshot 2024-11-15 at 1 56 02 PM](https://github.com/user-attachments/assets/b21df2d4-3247-4e1b-9108-a1169421b827)
