### PR TITLE
Update Timeout Configuration from 30 Minute Default to 8 Hours

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -187,7 +187,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 8.hours
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
Updates Devise configuration to update user session timeout from the 30 minute default to 8 hours. This update is intended to fix login issues experienced by PSO users.

### Reference
[Issue 860: Change timeoutable config to 8 hours](https://github.com/pgharts/trusty-cms/issues/860)