### PR TITLE
Add Scheduled Status Validation JavaScript to Asset Pipeline

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.3)
+    trusty-cms (7.0.5)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/assets/config/trusty-cms-manifest.js
+++ b/app/assets/config/trusty-cms-manifest.js
@@ -4,3 +4,4 @@
 //= link admin/assets.css
 //= link admin/assets_admin.js
 //= link admin/custom_file_upload.js
+//= link admin/validations/scheduled_status_validation.js

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '7.0.4'.freeze
+  VERSION = '7.0.5'.freeze
 end
 


### PR DESCRIPTION
This bugfix aims to resolve the error below by adding the `scheduled_status_validation.js` file to the asset pipeline. This PR also updates the gem version to `7.0.5`.

```
Sprockets::Rails::Helper::AssetNotPrecompiledError: Asset `admin/validations/scheduled_status_validation.js` 
was not declared to be precompiled in production. Declare links to your assets in `app/assets/config/manifest.js`. 
//= link admin/validations/scheduled_status_validation.js and restart your server
```