### PR TITLE
Fix Layout Save Issue

### DIFF
--- a/app/assets/javascripts/admin/validations/scheduled_status_validation.js
+++ b/app/assets/javascripts/admin/validations/scheduled_status_validation.js
@@ -51,7 +51,7 @@ $(document).ready(function() {
     }
   }
 
-  $('#save-button, #save-and-continue-button').on('click', function(event) {
+  $('input[value="Save Changes"], input[value="Save and Continue Editing"]').on('click', function(event) {
     if (!validateDateTime()) {
       event.preventDefault();
       event.stopImmediatePropagation();

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,12 +33,11 @@ module ApplicationHelper
       t('buttons.save_changes', default: 'Save Changes')
     options[:class] ||= 'button'
     options[:accesskey] ||= 'S'
-    options[:id] ||= 'save-button'
     submit_tag options.delete(:label), options
   end
 
   def save_model_and_continue_editing_button(_model)
-    submit_tag t('buttons.save_and_continue'), name: 'continue', class: 'button', accesskey: 's', id: 'save-and-continue-button'
+    submit_tag t('buttons.save_and_continue'), name: 'continue', class: 'button', accesskey: 's'
   end
 
   def current_item?(item)

--- a/app/views/admin/pages/_fields.html.haml
+++ b/app/views/admin/pages/_fields.html.haml
@@ -73,10 +73,6 @@
     #preview_panel.fullcover.grey_out{:style => 'display: none;'}
       %iframe{:id => 'page-preview', :class => 'fullcover', :name => 'page-preview', :src =>  ActionController::Base.relative_url_root.to_s + '/loading-iframe.html', :frameborder => 0, :scrolling => 'auto'}
       .preview_tools
-        =submit_tag(t('buttons.save_changes'), :class => 'big save_changes')
-        =submit_tag(t('buttons.save_and_continue'), :class => 'big save_and_continue', :name => 'continue')
-        %span.info
-          = t('or')
-          =link_to(t('edit_page'),{}, :class => 'cancel')
+        =link_to(t('edit_page'), {}, :class => 'button cancel')
   - form_bottom.edit_timestamp do
     = updated_stamp @page


### PR DESCRIPTION
This pull request reverts recent changes that utilized an ID on the "Save" and "Save and Continue Editing" buttons that broke the layout save functions. Reverting this change and utilizing a JQuery input value selector instead resolves this issue and allows users to save layouts, while ensuring Page status validations still run.

This pull request also removes the Save buttons from the Preview toolbar to ensure the validations are run. This requires the user to return to the page editor to save the page.

### Reference
[Issue 869: Layout Save Function is Broken](https://github.com/pgharts/trusty-cms/issues/869)