### PR TITLE
Add Page Version Restore Feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ source 'https://rubygems.org'
 # requires trusty and therefore pulls in every
 # dependency mentioned in trusty.gemspec.
 
+gem 'paper_trail'
+gem 'paper_trail-association_tracking'
+gem 'psych', '5.2.0'
 gem 'trustygems', '~> 0.2.0'
 
 gemspec
@@ -19,11 +22,8 @@ group :development, :test do
   gem 'file_validators'
   gem 'launchy', '~> 3.0.1'
   gem 'mysql2'
-  gem 'paper_trail'
-  gem 'paper_trail-association_tracking'
   gem 'poltergeist', '~> 1.18.1'
   gem 'pry-byebug'
-  gem 'psych', '5.2.0'
   gem 'rails-observers'
   gem 'ransack'
   gem 'rspec-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ group :development, :test do
   gem 'file_validators'
   gem 'launchy', '~> 3.0.1'
   gem 'mysql2'
+  gem 'paper_trail'
+  gem 'paper_trail-association_tracking'
   gem 'poltergeist', '~> 1.18.1'
   gem 'pry-byebug'
   gem 'psych', '5.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.3)
+    trusty-cms (7.0.5)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)
@@ -165,7 +165,16 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
-    ffi (1.17.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     file_validators (3.0.0)
       activemodel (>= 3.2)
       mime-types (>= 1.0)
@@ -256,6 +265,11 @@ GEM
     nokogiri (1.17.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    paper_trail (16.0.0)
+      activerecord (>= 6.1)
+      request_store (~> 1.4)
+    paper_trail-association_tracking (2.2.1)
+      paper_trail (>= 12.0)
     poltergeist (1.18.1)
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
@@ -316,6 +330,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.11)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -412,6 +428,8 @@ DEPENDENCIES
   file_validators
   launchy (~> 3.0.1)
   mysql2
+  paper_trail
+  paper_trail-association_tracking
   poltergeist (~> 1.18.1)
   pry-byebug
   psych (= 5.2.0)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -44,11 +44,8 @@ class Admin::PagesController < Admin::ResourceController
   end
 
   def restore
-    lock_version = @page.lock_version
     index = params[:version_index].to_i
-    restored_page = @page.versions[index].reify(has_many: true)
-    restored_page.lock_version = lock_version
-    restored_page.save!
+    restore_page_version(@page, index)
     redirect_to edit_admin_page_path(@page)
   end
 
@@ -95,6 +92,13 @@ class Admin::PagesController < Admin::ResourceController
           updated_by: User.unscoped.find_by(id: version&.whodunnit)&.name || 'Unknown User'
         }
       end
+  end
+
+  def restore_page_version(page, index)
+    lock_version = page.lock_version
+    restored_page = page.versions[index].reify(has_many: true)
+    restored_page.lock_version = lock_version
+    restored_page.save!
   end
 
   def model_class

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -1,6 +1,7 @@
 class Admin::PagesController < Admin::ResourceController
   before_action :initialize_meta_rows_and_buttons, only: %i[new edit create update]
   before_action :count_deleted_pages, only: [:destroy]
+  before_action :set_page, only: %i[edit restore]
   rescue_from ActiveRecord::RecordInvalid, with: :validation_error
 
   class PreviewStop < ActiveRecord::Rollback
@@ -38,32 +39,17 @@ class Admin::PagesController < Admin::ResourceController
     assets = Asset.order('created_at DESC')
     @term = assets.ransack(params[:search] || '')
     @term.result(distinct: true)
-    @page = Page.find(params[:id])
-    @versions = if @page.versions.any?
-      @page.versions
-        .sort_by(&:created_at).reverse
-        .map do |version|
-          {
-            index: version&.index,
-            update_date: version&.created_at&.strftime("%B %d, %Y"),
-            update_time: version&.created_at&.strftime("%I:%M %p"),
-            updated_by: User.unscoped.find_by(id: version&.whodunnit)&.name || 'Unknown User'
-          }
-      end
-    else
-      nil
-    end
+    @versions = format_versions(@page.versions)
     response_for :edit
   end
 
   def restore
-    page = Page.find(params[:id])
-    lock_version = page.lock_version
+    lock_version = @page.lock_version
     index = params[:version_index].to_i
-    restored_page = page.versions[index].reify(has_many: true)
+    restored_page = @page.versions[index].reify(has_many: true)
     restored_page.lock_version = lock_version
     restored_page.save!
-    redirect_to edit_admin_page_path(page)
+    redirect_to edit_admin_page_path(@page)
   end
 
   def preview
@@ -80,6 +66,10 @@ class Admin::PagesController < Admin::ResourceController
 
   private
 
+  def set_page
+    @page = Page.find(params[:id])
+  end
+
   def validation_error(e)
     flash[:error] = e.message
     render :new
@@ -90,6 +80,21 @@ class Admin::PagesController < Admin::ResourceController
       model.slug = '/'
     end
     model.parent_id = params[:page_id]
+  end
+
+  def format_versions(versions)
+    return nil unless versions.any?
+
+    versions
+      .sort_by(&:created_at).reverse
+      .map do |version|
+        {
+          index: version&.index,
+          update_date: version&.created_at&.strftime("%B %d, %Y"),
+          update_time: version&.created_at&.strftime("%I:%M %p"),
+          updated_by: User.unscoped.find_by(id: version&.whodunnit)&.name || 'Unknown User'
+        }
+      end
   end
 
   def model_class

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -87,9 +87,9 @@ class Admin::PagesController < Admin::ResourceController
       .map do |version|
         {
           index: version&.index,
-          update_date: version&.created_at&.strftime("%B %d, %Y"),
-          update_time: version&.created_at&.strftime("%I:%M %p"),
-          updated_by: User.unscoped.find_by(id: version&.whodunnit)&.name || 'Unknown User'
+          update_date: version&.created_at&.strftime('%B %d, %Y'),
+          update_time: version&.created_at&.strftime('%I:%M %p'),
+          updated_by: User.unscoped.find_by(id: version&.whodunnit)&.name || 'Unknown User',
         }
       end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   before_action :force_utf8_params if RUBY_VERSION =~ /1\.9/
   before_action :set_standard_body_style, only: %i[new edit update create]
   before_action :set_mailer
+  before_action :set_paper_trail_whodunnit
 
   attr_accessor :trusty_config, :cache
   attr_reader :pagination_parameters

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,8 @@
 require 'trusty_cms/taggable'
 
 class Page < ActiveRecord::Base
+  has_paper_trail
+  
   class MissingRootPageError < StandardError
     def initialize(message = 'Database missing root page')
       ; super
@@ -12,9 +14,9 @@ class Page < ActiveRecord::Base
 
   # Associations
   acts_as_tree order: 'position ASC'
-  has_many :parts, -> { order(:id) }, class_name: 'PagePart', dependent: :destroy
+  has_many :parts, -> { order(:id) }, class_name: 'PagePart', autosave: true, dependent: :destroy
   accepts_nested_attributes_for :parts, allow_destroy: true
-  has_many :fields, -> { order(:id) }, class_name: 'PageField', dependent: :destroy
+  has_many :fields, -> { order(:id) }, class_name: 'PageField', autosave: true, dependent: :destroy
   accepts_nested_attributes_for :fields, allow_destroy: true
   belongs_to :layout
   belongs_to :created_by, class_name: 'User'

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,9 +14,9 @@ class Page < ActiveRecord::Base
 
   # Associations
   acts_as_tree order: 'position ASC'
-  has_many :parts, -> { order(:id) }, class_name: 'PagePart', autosave: true, dependent: :destroy
+  has_many :parts, -> { order(:id) }, class_name: 'PagePart', foreign_key: :page_id, autosave: true, dependent: :destroy
   accepts_nested_attributes_for :parts, allow_destroy: true
-  has_many :fields, -> { order(:id) }, class_name: 'PageField', autosave: true, dependent: :destroy
+  has_many :fields, -> { order(:id) }, class_name: 'PageField', foreign_key: :page_id, autosave: true, dependent: :destroy
   accepts_nested_attributes_for :fields, allow_destroy: true
   belongs_to :layout
   belongs_to :created_by, class_name: 'User'

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,7 +2,7 @@ require 'trusty_cms/taggable'
 
 class Page < ActiveRecord::Base
   has_paper_trail
-  
+
   class MissingRootPageError < StandardError
     def initialize(message = 'Database missing root page')
       ; super

--- a/app/models/page_field.rb
+++ b/app/models/page_field.rb
@@ -1,3 +1,4 @@
 class PageField < ActiveRecord::Base
+  has_paper_trail
   validates_presence_of :name
 end

--- a/app/models/page_part.rb
+++ b/app/models/page_part.rb
@@ -1,4 +1,6 @@
 class PagePart < ActiveRecord::Base
+  has_paper_trail
+  
   # Default Order
   default_scope { order('name') }
 

--- a/app/models/page_part.rb
+++ b/app/models/page_part.rb
@@ -1,6 +1,6 @@
 class PagePart < ActiveRecord::Base
   has_paper_trail
-  
+
   # Default Order
   default_scope { order('name') }
 

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,1 @@
+PaperTrail.config.track_associations = true

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,2 @@
 PaperTrail.config.track_associations = true
+PaperTrail.config.version_limit = 5

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ TrustyCms::Application.routes.draw do
     resources :pages do
       resources :children, controller: 'pages'
       get 'remove', on: :member
+      put 'restore/:version_index', on: :member, to: 'pages#restore', as: :restore_version
     end
     resources :layouts do
       get 'remove', on: :member

--- a/db/migrate/20250102212417_create_versions.rb
+++ b/db/migrate/20250102212417_create_versions.rb
@@ -1,0 +1,41 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[7.0]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+      # Consider using bigint type for performance if you are going to store only numeric ids.
+      # t.bigint   :whodunnit
+      t.string   :whodunnit
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+
+      t.bigint   :item_id,   null: false
+      t.string   :item_type, null: false, limit: 191
+      t.string   :event,     null: false
+      t.text     :object, limit: TEXT_BYTES
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20250103191133_create_version_associations.rb
+++ b/db/migrate/20250103191133_create_version_associations.rb
@@ -1,0 +1,23 @@
+# This migration and AddTransactionIdColumnToVersions provide the necessary
+# schema for tracking associations.
+class CreateVersionAssociations < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :version_associations do |t|
+      t.integer  :version_id
+      t.string   :foreign_key_name, null: false
+      t.integer  :foreign_key_id
+      t.string   :foreign_type
+    end
+    add_index :version_associations, [:version_id]
+    add_index :version_associations,
+      %i(foreign_key_name foreign_key_id foreign_type),
+      name: "index_version_associations_on_foreign_key"
+  end
+
+  def self.down
+    remove_index :version_associations, [:version_id]
+    remove_index :version_associations,
+      name: "index_version_associations_on_foreign_key"
+    drop_table :version_associations
+  end
+end

--- a/db/migrate/20250103191134_add_transaction_id_column_to_versions.rb
+++ b/db/migrate/20250103191134_add_transaction_id_column_to_versions.rb
@@ -1,0 +1,13 @@
+# This migration and CreateVersionAssociations provide the necessary
+# schema for tracking associations.
+class AddTransactionIdColumnToVersions < ActiveRecord::Migration[7.0]
+  def self.up
+    add_column :versions, :transaction_id, :integer
+    add_index :versions, [:transaction_id]
+  end
+
+  def self.down
+    remove_index :versions, [:transaction_id]
+    remove_column :versions, :transaction_id
+  end
+end

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '7.0.4'.freeze
+  VERSION = '7.0.5'.freeze
 end
 


### PR DESCRIPTION
This PR introduces the ability to revert to a previous version of a page using the `paper_trail` gem alongside the `paper_trail-association_tracking` plugin. Users can now restore pages to a specific historical state, including associated data, while preserving version history.

- Saves version history for the last five versions of a Page.
- Saves associated `PagePart` and `PageField` objects.

### Notes
This feature does not save parts of a page that are independently saved, such as Related Sections or Persons. 

### Screenshot
![Page Restore Screenshot](https://github.com/user-attachments/assets/a36c4ac7-ec5e-4e13-893f-a614fc6edf3a)

### Reference
[Issue 714: Create a "Version Control" ability for Pages](https://github.com/pgharts/trusty-cms/issues/714)