### PR TITLE
Add the ability to update the Parent of a Page

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -3,6 +3,7 @@ class Admin::PagesController < Admin::ResourceController
   before_action :count_deleted_pages, only: [:destroy]
   before_action :set_page, only: %i[edit restore]
   rescue_from ActiveRecord::RecordInvalid, with: :validation_error
+  include Admin::PagesHelper
 
   class PreviewStop < ActiveRecord::Rollback
     def message
@@ -113,13 +114,13 @@ class Admin::PagesController < Admin::ResourceController
     versions
       .sort_by(&:created_at).reverse
       .map do |version|
-        {
-          index: version&.index,
-          update_date: version&.created_at&.strftime('%B %d, %Y'),
-          update_time: version&.created_at&.strftime('%I:%M %p'),
-          updated_by: User.unscoped.find_by(id: version&.whodunnit)&.name || 'Unknown User',
-        }
-      end
+      {
+        index: version&.index,
+        update_date: version&.created_at&.strftime('%B %d, %Y'),
+        update_time: version&.created_at&.strftime('%I:%M %p'),
+        updated_by: User.unscoped.find_by(id: version&.whodunnit)&.name || 'Unknown User',
+      }
+    end
   end
 
   def restore_page_version(page, index)

--- a/app/helpers/admin/pages_helper.rb
+++ b/app/helpers/admin/pages_helper.rb
@@ -17,4 +17,10 @@ module Admin::PagesHelper
   def clean_page_description(page)
     page.description.to_s.strip.gsub(/\t/, '').gsub(/\s+/, ' ')
   end
+
+  def parent_page_options(current_site, page)
+    parent_pages = Page.parent_pages(current_site.homepage_id)
+    selected_page_id = page.id.presence_in(parent_pages.pluck(:id)) || page.parent_id.presence_in(parent_pages.pluck(:id))
+    options_for_select(parent_pages.map { |p| [p.title, p.id] }, selected_page_id)
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -159,6 +159,10 @@ class Page < ActiveRecord::Base
     ['site_id', 'title']
   end
 
+  def self.parent_pages(homepage_id)
+    where(parent_id: homepage_id).or(where(id: homepage_id))
+  end
+
   private :set_response_headers
 
   def set_content_type(response)

--- a/app/views/admin/pages/_fields.html.haml
+++ b/app/views/admin/pages/_fields.html.haml
@@ -1,7 +1,6 @@
 = fields.hidden_field :lock_version
 = fields.hidden_field :parent_id
 = fields.hidden_field :class_name
-
 = render_region :form_top, :locals => {:f => fields}
 
 - render_region :form, :locals => {:f => fields} do |form|
@@ -43,6 +42,10 @@
       .page-type
         = fields.label :class_name, t('page_type')
         = fields.select :class_name, [[t('select.normal'), '']] + Page.descendants.map { |p| [p.display_name, p.name] }.sort_by { |p| p.first }
+    - layout.edit_parent do
+      .parent-page
+        = fields.label :parent_id, t('parent_page')
+        = fields.select :parent_id, parent_page_options(current_site, @page)
     - layout.edit_status do
       - if current_user.admin? || current_user.editor?
         .status
@@ -56,6 +59,7 @@
             class: 'datetime',
             type: 'datetime-local',
             value: (@page.published_at? ? @page.published_at.strftime('%Y-%m-%dT%H:%M') : nil)
+
     = render_region :layout_row, :locals => {:f => fields}
 
 .error.hidden

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,7 @@ en:
     removed_many: "The pages were successfully removed from the site."
     removed_one: "The page was successfully removed from the site."
     saved: "Your page has been saved below."
+  parent_page: 'Parent Page'
   password: 'Password'
   password_confirmation: 'Confirm New Password'
   personal: 'Personal'

--- a/lib/trusty_cms/admin_ui.rb
+++ b/lib/trusty_cms/admin_ui.rb
@@ -170,7 +170,7 @@ module TrustyCms
         page.edit = RegionSet.new do |edit|
           edit.main.concat %w{edit_header edit_form edit_popups}
           edit.form.concat %w{edit_title edit_extended_metadata edit_page_parts}
-          edit.layout.concat %w{edit_layout edit_type edit_status edit_published_at}
+          edit.layout.concat %w{edit_layout edit_type edit_parent edit_status edit_published_at}
           edit.form_bottom.concat %w{edit_buttons edit_timestamp}
         end
         page.index = RegionSet.new do |index|

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '7.0.9'.freeze
+  VERSION = '7.0.10'.freeze
 end
 


### PR DESCRIPTION
## Description
Add the ability to update the Parent of a Page

## Related Tickets & Documents
- Resolves #858

## QA Instructions, Screenshots, Recordings

_You should be able to change the parent of any page in the CMS_
_By clicking page, scrolling to the bottom of the page and choosing the "Parent" dropdown you will see a top level list of parent pages. To help the usability and UX of this feature, I chose to only use the very top level pages. This ensures an easy to read and use drop down. For nested pages, the user will still have to delete and recreate under a different parent._

![Screenshot 2025-01-17 at 1 09 51 PM](https://github.com/user-attachments/assets/02a0ccb1-7040-4298-bf5b-2f118dd8b128)
![Screenshot 2025-01-17 at 1 09 58 PM](https://github.com/user-attachments/assets/02f88fd1-0c8a-4b47-b9c8-dda30476e48a)


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: _we have no tests for the page model. [I created an issue to get this coverage up.](https://github.com/pgharts/trusty-cms/issues/876) _
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
If you have a pages_helper.rb for admin/helpers - you will need to copy the new helper method to the file. 