### PR TITLE
Fix nil Value Conditional Error for Page Status Refresh

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.9)
+    trusty-cms (7.0.11)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/controllers/page_status_controller.rb
+++ b/app/controllers/page_status_controller.rb
@@ -32,7 +32,8 @@ class PageStatusController < ApplicationController
 
     pages.each do |page|
       page_id = page.id
-      if page.published_at && page.published_at <= Time.now
+      published_at = page.published_at
+      if published_at && published_at <= Time.now
         page.update(status_id: Status[:published].id)
         updated_pages << page_id
       else

--- a/app/controllers/page_status_controller.rb
+++ b/app/controllers/page_status_controller.rb
@@ -32,7 +32,7 @@ class PageStatusController < ApplicationController
 
     pages.each do |page|
       page_id = page.id
-      if page.published_at <= Time.now
+      if page.published_at && page.published_at <= Time.now
         page.update(status_id: Status[:published].id)
         updated_pages << page_id
       else

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '7.0.10'.freeze
+  VERSION = '7.0.11'.freeze
 end
 


### PR DESCRIPTION
Rails was throwing a `undefined method '<=' for nil` on `page.published_at <= Time.now`. This pull request ensures that a valid `published_at` value exists before the less than or equal to operator.