### PR TITLE
Implement Google Tag Manager for Admin Page Tracking and Enhance Credential Access Safety

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.11)
+    trusty-cms (7.0.12)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/README.md
+++ b/README.md
@@ -93,17 +93,25 @@ SecureRandom.base58(24)
 ```  
 
 **2. Store the Token in Rails Credentials**  
-Run the following command to edit your credentials:  
+To store your token securely, edit your Rails credentials by running the following command:
 ```bash
 bin/rails encrypted:edit config/credentials.yml.enc
-```  
-Add the token to your credentials:  
+```
+Then, add the token to your credentials file under the `trusty_cms` namespace:
 ```yaml
 trusty_cms:
   page_status_bearer_token: '<your bearer token>'
-```  
+```
 
-**3. Create a Ruby Lambda Function in AWS**  
+**3. Add Google Tag Manager Container ID (Optional)**
+If you'd like to enable trusty-cms to submit Google Tag Manager data for tracking admin page activity (this does not include public-facing pages), add your Google Tag Manager Container ID to the `trusty_cms` section of your `credentials.yml.enc` file:
+ ```yaml
+trusty_cms:
+  page_status_bearer_token: '<your bearer token>'
+  gtm_container_id: 'GTM-xxxxxx'
+```
+
+**4. Create a Ruby Lambda Function in AWS**  
 - Log into **AWS Lambda** and create a **new Ruby Lambda function**.  
 - Note the **Ruby version** used, as you'll need it locally.  
 - Use [rbenv](https://github.com/rbenv/rbenv) to manage the Ruby version locally:  
@@ -112,7 +120,7 @@ trusty_cms:
   rbenv local 3.3.0
   ```
 
-**4. Write the Lambda Function Code**  
+**5. Write the Lambda Function Code**  
 In your local development environment:  
 - Create a new folder and open it in your IDE.  
 - Save the following code in a file named `lambda_handler.rb`:  
@@ -140,7 +148,7 @@ def lambda_handler(event:, context:)
 end
 ```
 
-**5. Install Dependencies**  
+**6. Install Dependencies**  
 Run the following commands in your terminal:  
 ```bash
 gem install bundler
@@ -156,25 +164,25 @@ bundle config set --local path 'vendor/bundle'
 bundle install
 ```
 
-**6. Package the Lambda Function**  
+**7. Package the Lambda Function**  
 Archive your function and dependencies:  
 ```bash
 zip -r lambda_package.zip .
 ```
 
-**7. Upload to AWS Lambda**  
+**8. Upload to AWS Lambda**  
 - In **AWS Lambda**, open your function.  
 - Select **Upload From > .zip file**.  
 - Upload the `lambda_package.zip` file.  
 
-**8. Configure Environment Variables**  
+**9. Configure Environment Variables**  
 In the AWS Lambda Configuration: 
 - Go to **Environment Variables** > **Edit**.  
 - Add the following:  
   - `API_ENDPOINT`: `<your-url>/page-status/refresh`  
   - `BEARER_TOKEN`: `<your bearer token>`  
 
-**9. Set Up EventBridge Trigger**  
+**10. Set Up EventBridge Trigger**  
 - In **Configuration Settings > Triggers**, create a **new EventBridge Trigger**.  
 - Set the **Schedule** to match your desired **page status refresh frequency**.  
 

--- a/app/controllers/page_status_controller.rb
+++ b/app/controllers/page_status_controller.rb
@@ -15,7 +15,7 @@ class PageStatusController < ApplicationController
 
   def authenticate_bearer_token
     provided_token = request.headers['Authorization']&.split(' ')&.last
-    expected_token = Rails.application.credentials[:trusty_cms][:page_status_bearer_token]
+    expected_token = Rails.application.credentials&.dig(:trusty_cms, :page_status_bearer_token)
 
     if provided_token.blank?
       render json: { error: 'Missing Bearer Token' }, status: :unauthorized and return

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,3 +1,4 @@
+- gtm_container_id = Rails.application.credentials&.dig(:trusty_cms, :gtm_container_id)
 <!DOCTYPE html>
 %html{ :xmlns => "http://www.w3.org/1999/xhtml", "xml:lang" => "en", :lang => "en", :class => "tablesaw-enhanced fontawesome-i2svg-active fontawesome-i2svg-complete" }
   %head
@@ -8,6 +9,19 @@
     - @stylesheets.uniq.each do |stylesheet|
       = stylesheet_link_tag stylesheet, media: "all"
 
+    - if gtm_container_id
+      %script{:type=>"text/javascript"}
+        :plain
+          (function(w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s),
+                dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+          })(window, document, 'script', 'dataLayer', "#{gtm_container_id}");
     %script{:type=>"text/javascript"}
       var relative_url_root = "#{ActionController::Base.relative_url_root}";
 
@@ -30,6 +44,9 @@
     = csrf_meta_tags
 
   %body{:class=>body_classes.join(" ")}
+    - if gtm_container_id
+      %noscript
+        %iframe{src: "https://www.googletagmanager.com/ns.html?id=#{gtm_container_id}", height: "0", width: "0", style: "display:none;visibility:hidden"}
     #page.trusty-container
       %header
         - if logged_in?

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '7.0.11'.freeze
+  VERSION = '7.0.12'.freeze
 end
 


### PR DESCRIPTION
This pull request introduces the integration of Google Tag Manager (GTM) into the admin pages of the TrustyCMS application. The primary objective is to monitor the usage frequency of the CKEditor, enabling us to assess monthly load requirements effectively.

Additionally, this update refines the method of accessing the page status refresh token credentials by incorporating the safe navigation operator (&.) and the dig method, thereby enhancing the robustness of credential retrieval and preventing potential errors.

This pull request updates TrustyCMS to version `7.0.12`.

### Reference
[Issue 6143: Add GTM to /admin pages](https://github.com/pgharts/culturaldistrict.org/issues/6143)