### PR TITLE
Fix SyntaxError in Admin::NodeHelper render_node Method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.9)
+    trusty-cms (7.0.9.1)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/helpers/admin/node_helper.rb
+++ b/app/helpers/admin/node_helper.rb
@@ -1,19 +1,19 @@
 module Admin::NodeHelper
   def render_nodes(page, starting_index, parent_index = nil, simple = false)
     @rendered_html = ''
-    render_node page, starting_index, parent_index, simple
+    render_node(page, starting_index, parent_index, simple)
     @rendered_html
   end
 
   def render_node(page, index, parent_index = nil, simple = false)
     @current_node = prepare_page(page)
-    @rendered_html += render_partial(page, index:, parent_index:, simple:)
+    @rendered_html += render_partial(page, index, parent_index, simple)
     index
   end
 
   def render_search_node(page)
     @current_node = prepare_page(page)
-    @rendered_html = render_partial(page, index: 0, parent_index: nil, simple: false)
+    @rendered_html = render_partial(page, 0, nil, false)
   end
 
   def prepare_page(page)
@@ -95,7 +95,7 @@ module Admin::NodeHelper
 
   private
 
-  def render_partial(page, index:, parent_index:, simple:)
+  def render_partial(page, index, parent_index, simple)
     render partial: 'admin/pages/node',
            locals: {
              level: index,

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '7.0.9'.freeze
+  VERSION = '7.0.9.1'.freeze
 end
 


### PR DESCRIPTION
The render_node method in Admin::NodeHelper was resulting in a SyntaxError due to incorrectly defined keyword arguments. This fix removes the keyword arguments and replaces them with positional arguments for simplicity's sake.