### PR TITLE
Remove Hidden Status from Pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.11)
+    trusty-cms (7.0.13)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/models/standard_tags.rb
+++ b/app/models/standard_tags.rb
@@ -103,7 +103,7 @@ module StandardTags
     <pre><code><r:children:each [offset="number"] [limit="number"]
      [by="published_at|updated_at|created_at|slug|title|keywords|description"]
      [order="asc|desc"]
-     [status="draft|reviewed|published|hidden|all"]
+     [status="draft|reviewed|scheduled|published|all"]
      [paginated="true"]
      [per_page="number"]
      >

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -32,6 +32,5 @@ class Status
     Status.new(id: 50,  name: 'Reviewed'),
     Status.new(id: 90,  name: 'Scheduled'),
     Status.new(id: 100, name: 'Published'),
-    Status.new(id: 101, name: 'Hidden'),
   ]
 end

--- a/config/locales/en_available_tags.yml
+++ b/config/locales/en_available_tags.yml
@@ -141,7 +141,7 @@ en:
       <pre><code><r:children:each [offset=\"number\"] [limit=\"number\"]
        [by=\"published_at|updated_at|created_at|slug|title|keywords|description\"]
        [order=\"asc|desc\"]
-       [status=\"draft|reviewed|published|hidden|all\"]
+       [status=\"draft|reviewed|scheduled|published|all\"]
        [paginated=\"true\"]
        [per_page=\"number\"]
        >

--- a/lib/generators/language_extension/templates/available_tags.yml
+++ b/lib/generators/language_extension/templates/available_tags.yml
@@ -107,7 +107,7 @@
 
       <pre><code><r&#58;children&#58;each [offset="number"] [limit="number"]
        [by="published_at|updated_at|created_at|slug|title|keywords|description"]
-       [order="asc|desc"] [status="draft|reviewed|published|hidden|all"]>
+       [order="asc|desc"] [status="draft|reviewed|scheduled|published|all"]>
        ...
       </r&#58;children&#58;each>
       </code></pre>

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.11'.freeze
+  VERSION = '7.0.13'.freeze
 end
-


### PR DESCRIPTION
This pull request removes the Hidden status option from pages in the CMS. Accompanying this PR are changes made directly to the database updating pages with the Hidden status to utilize the Draft status.

### To-Do
After merging this pull request, run the following SQL statement to update pages with the Hidden status to Draft status on the staging and production databases for Cultural District and Festivity.

```sql
UPDATE pages 
SET status_id = 1 
WHERE status_id = 101;
```

### Reference
Resolves [Issue 852: Jenga "Hidden" page status](https://github.com/pgharts/trusty-cms/issues/852)