### PR TITLE
Add Path Column to Page Search Results

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.11)
+    trusty-cms (7.0.14)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/assets/stylesheets/admin/partials/_table.scss
+++ b/app/assets/stylesheets/admin/partials/_table.scss
@@ -23,6 +23,10 @@ table {
       width: 100%;
     }
 
+    &.path {
+      min-width: 8em;
+    }
+
     &.status {
       min-width: 8em;
     }

--- a/app/helpers/admin/node_helper.rb
+++ b/app/helpers/admin/node_helper.rb
@@ -11,9 +11,9 @@ module Admin::NodeHelper
     index
   end
 
-  def render_search_node(page)
+  def render_search_node(page, index = 0, parent_index = nil, simple = false)
     @current_node = prepare_page(page)
-    @rendered_html = render_partial(page, index: 0, parent_index: nil, simple: false)
+    @rendered_html = render_search_partial(page, index:, parent_index:, simple:, path: format_path(page.path))
   end
 
   def prepare_page(page)
@@ -23,6 +23,17 @@ module Admin::NodeHelper
       page.extend(*page.menu_renderer_modules)
     end
     page
+  end
+
+  def format_path(path)
+    return "" if path.nil? || path.empty?
+  
+    parts = path.split('/').reject(&:empty?)
+    return "Root" if parts.size == 1
+    return "/" if parts.size == 2
+  
+    formatted_path = parts[1..-2].join('/')
+    formatted_path.empty? ? "/" : "/#{formatted_path}"
   end
 
   def homepage
@@ -104,6 +115,19 @@ module Admin::NodeHelper
              page: page,
              simple: simple,
              branch: page.children.count.positive?,
+           }
+  end
+
+  def render_search_partial(page, index:, parent_index:, simple:, path:)
+    render partial: 'admin/pages/search_result_node',
+           locals: {
+             level: index,
+             index: index,
+             parent_index: parent_index,
+             page: page,
+             simple: simple,
+             branch: false,
+             path: path,
            }
   end
 end

--- a/app/helpers/admin/node_helper.rb
+++ b/app/helpers/admin/node_helper.rb
@@ -26,14 +26,14 @@ module Admin::NodeHelper
   end
 
   def format_path(path)
-    return "" if path.nil? || path.empty?
-  
+    return '' if path.nil? || path.empty?
+
     parts = path.split('/').reject(&:empty?)
-    return "Root" if parts.size == 1
-    return "/" if parts.size == 2
-  
+    return 'Root' if parts.size == 1
+    return '/' if parts.size == 2
+
     formatted_path = parts[1..-2].join('/')
-    formatted_path.empty? ? "/" : "/#{formatted_path}"
+    formatted_path.empty? ? '/' : "/#{formatted_path}"
   end
 
   def homepage

--- a/app/views/admin/pages/_search_result_node.html.haml
+++ b/app/views/admin/pages/_search_result_node.html.haml
@@ -1,0 +1,25 @@
+%tr.page
+  - render_region :node, :locals => {:page => page, :level => level, :simple => simple, :path => path} do |node|
+    - node.title_column do
+      %td.name
+        %span.w1
+          - if simple
+            = node_title
+          - else
+            %i.far.fa-file
+            = (link_to("#{node_title}".html_safe, edit_admin_page_path(page), :title => page.path)).html_safe
+            = page_type
+            = spinner
+    - node.path_column do
+      %td.path
+        = path
+    - node.status_column do
+      - unless simple
+        %td.status
+          %span.status{:class => "#{page.status.name.downcase}_status", :title => "#{timestamp(page.published_at) if page.published_at}"}= t(page.status.name.downcase)
+    - node.actions_column do
+      - unless simple
+        %td.actions
+          = page.add_child_option
+          - if current_user.editor? || current_user.admin?
+            = page.remove_option            

--- a/app/views/admin/pages/_search_result_node.html.haml
+++ b/app/views/admin/pages/_search_result_node.html.haml
@@ -1,5 +1,5 @@
 %tr.page
-  - render_region :node, :locals => {:page => page, :level => level, :simple => simple, :path => path} do |node|
+  - render_region :node, :locals => { :page => page, :level => level, :simple => simple, :path => path } do |node|
     - node.title_column do
       %td.name
         %span.w1
@@ -16,10 +16,10 @@
     - node.status_column do
       - unless simple
         %td.status
-          %span.status{:class => "#{page.status.name.downcase}_status", :title => "#{timestamp(page.published_at) if page.published_at}"}= t(page.status.name.downcase)
+          %span.status{ :class => "#{page.status.name.downcase}_status", :title => "#{timestamp(page.published_at) if page.published_at}" }= t(page.status.name.downcase)
     - node.actions_column do
       - unless simple
         %td.actions
           = page.add_child_option
           - if current_user.editor? || current_user.admin?
-            = page.remove_option            
+            = page.remove_option

--- a/app/views/admin/pages/search.html.haml
+++ b/app/views/admin/pages/search.html.haml
@@ -9,6 +9,8 @@
         - render_region :sitemap_head do |sitemap_head|
           - sitemap_head.title_column_header do
             %th.name= t('page')
+          - sitemap_head.path_column_header do
+            %th.path= t('path')
           - sitemap_head.status_column_header do
             %th.status= t('status')
           - sitemap_head.actions_column_header do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,7 @@ en:
   parent_page: 'Parent Page'
   password: 'Password'
   password_confirmation: 'Confirm New Password'
+  path: 'Path'
   personal: 'Personal'
   personal_preferences: 'Personal Preferences'
   please_login: 'Please Login'

--- a/lib/trusty_cms/admin_ui.rb
+++ b/lib/trusty_cms/admin_ui.rb
@@ -178,8 +178,8 @@ module TrustyCms
           index.node.concat %w{title_column status_column actions_column}
         end
         page.search = RegionSet.new do |search|
-          search.sitemap_head.concat %w{title_column_header status_column_header actions_column_header}
-          search.node.concat %w{title_column status_column actions_column}
+          search.sitemap_head.concat %w{title_column_header path_column_header status_column_header actions_column_header}
+          search.node.concat %w{title_column path_column status_column actions_column}
         end
         page.remove = page.children = page.index
         page.new = page._part = page.edit

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '7.0.11'.freeze
+  VERSION = '7.0.14'.freeze
 end
 


### PR DESCRIPTION
### Description
This pull request introduces a Path column to the Page Search results, enabling users to quickly identify a page’s location within the page hierarchy.

### Changes
- **Added a Path column:** Displays the full path of each page in search results for easier navigation.
- **Removed the dropdown function for displaying child pages:** The updated template caused rendering issues, so this functionality was removed.

### Why?
The Path column was requested to help users locate pages more efficiently.

### Screenshot
![Page Search Results with Path Column](https://github.com/user-attachments/assets/e8a5ba4f-b6fa-4d51-8074-2fa37066b625)

### Reference
Resolves [Add Path to Page Search Results](https://github.com/pgharts/trusty-cms/issues/907)