### PR TITLE
Set sign_out_all_scopes to False

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.11)
+    trusty-cms (7.0.15)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -251,7 +251,7 @@ Devise.setup do |config|
 
   # Set this configuration to false if you want /users/sign_out to sign out
   # only the current scope. By default, Devise signs out all scopes.
-  # config.sign_out_all_scopes = true
+  config.sign_out_all_scopes = false
 
   # ==> Navigation configuration
   # Lists the formats that should be treated as navigational. Formats like

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,4 +1,4 @@
 module TrustyCms
-  VERSION = '7.0.11'.freeze
+  VERSION = '7.0.15'.freeze
 end
 


### PR DESCRIPTION
We are attempting to resolve a log out issue. When a user is logged into the Admin pages, opens a new tab, navigates to a non-Admin site and returns to the Admin tab, the user is signed out when they select any button. In this PR, we set `sign_out_all_scopes` to `false` to see if this resolves this issue.

### Reference
[Issue 736: Include site_id query param in all actions ](https://github.com/pgharts/trusty-cms/issues/736)