### PR TITLE
Set Devise expire_all_remember_me_on_sign_out Setting to False

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.16)
+    trusty-cms (7.0.17)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -166,7 +166,7 @@ Devise.setup do |config|
   # config.remember_for = 2.weeks
 
   # Invalidates all the remember me tokens when the user signs out.
-  config.expire_all_remember_me_on_sign_out = true
+  config.expire_all_remember_me_on_sign_out = false
 
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.16'.freeze
+  VERSION = '7.0.17'.freeze
 end


### PR DESCRIPTION
### Description
Sets Devise setting `expire_all_remember_me_on_sign_out` to `false` in hopes that it will resolve our Admin logout issue. The pull request updates TrustyCMS to version `7.0.17`.

### Reference
[Issue 905: Change expire_all_remember_me_on_sign_out to false](https://github.com/pgharts/trusty-cms/issues/905)