### PR TITLE
Parent Pages: Not always correctly showing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.16)
+    trusty-cms (7.0.17)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/helpers/admin/pages_helper.rb
+++ b/app/helpers/admin/pages_helper.rb
@@ -19,8 +19,10 @@ module Admin::PagesHelper
   end
 
   def parent_page_options(current_site, page)
-    parent_pages = Page.parent_pages(current_site.homepage_id)
-    selected_page_id = page.id.presence_in(parent_pages.pluck(:id)) || page.parent_id.presence_in(parent_pages.pluck(:id))
+    parent_pages = []
+    parent_pages.concat(Page.parent_pages(current_site.homepage_id))
+    parent_pages << page.parent if page.parent
+    selected_page_id = page.parent_id
     options_for_select(parent_pages.map { |p| [p.title, p.id] }, selected_page_id)
   end
 end

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.16'.freeze
+  VERSION = '7.0.17'.freeze
 end


### PR DESCRIPTION
The Parent Pages were not always correctly showing in the dropdown - If they were already in the top level list they were showing themselves (ie: About showing the About as parent) OR if they were nested under 2 parents, they were not showing their parents either. 

I did a little refactoring to just include the page's parent in the drop down and use that as the selected parent page. This will at least not mess with the parent id of the selected page and the user can then choose a parent if they need to.

Again this only shows the top level parent. More than that and the list just gets too long and busy. We can revisit that if its a real problem but this should suffice anything major.