### PR TITLE
Revert sign_out_all_scopes to True

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -251,7 +251,7 @@ Devise.setup do |config|
 
   # Set this configuration to false if you want /users/sign_out to sign out
   # only the current scope. By default, Devise signs out all scopes.
-  config.sign_out_all_scopes = false
+  config.sign_out_all_scopes = true
 
   # ==> Navigation configuration
   # Lists the formats that should be treated as navigational. Formats like


### PR DESCRIPTION
Reverts the the `config.sign_out_all_scopes` value to `true`. This value was changed to test if it resolved the Admin logout issue, but it did not.

### Reference
[Issue 736: Include site_id query param in all actions ](https://github.com/pgharts/trusty-cms/issues/736)