### PR TITLE
Add Site ID Verification and Refactor Page Edit Action

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.18)
+    trusty-cms (7.0.19)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -47,9 +47,7 @@ class Admin::PagesController < Admin::ResourceController
 
   def edit
     verify_site_id
-    assets = Asset.order('created_at DESC')
-    @term = assets.ransack(params[:search] || '')
-    @term.result(distinct: true)
+    load_assets
     @versions = format_versions(@page.versions)
     response_for :edit
   end
@@ -86,9 +84,15 @@ class Admin::PagesController < Admin::ResourceController
 
   def verify_site_id
     @site_id = params[:site_id]&.to_i
-    if @site_id == nil || @page&.site_id != @site_id
+    unless @site_id && @page&.site_id == @site_id
       redirect_to admin_pages_url
     end
+  end
+
+  def load_assets
+    assets = Asset.order(created_at: :desc)
+    @term = assets.ransack(params[:search].presence || {})
+    @term.result(distinct: true)
   end
 
   def initialize_search

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -46,6 +46,7 @@ class Admin::PagesController < Admin::ResourceController
   end
 
   def edit
+    verify_site_id
     assets = Asset.order('created_at DESC')
     @term = assets.ransack(params[:search] || '')
     @term.result(distinct: true)
@@ -81,6 +82,13 @@ class Admin::PagesController < Admin::ResourceController
     @site ||= Page.current_site
     @homepage = @site&.homepage || Page.homepage
     @site_id = @site&.id
+  end
+
+  def verify_site_id
+    @site_id = params[:site_id]&.to_i
+    if @site_id == nil || @page&.site_id != @site_id
+      redirect_to admin_pages_url
+    end
   end
 
   def initialize_search

--- a/app/views/admin/pages/_fields.html.haml
+++ b/app/views/admin/pages/_fields.html.haml
@@ -74,7 +74,7 @@
       = save_model_and_continue_editing_button(@page)
       = submit_tag(t('preview', :default => 'Preview'), :class => 'button', :id => 'show-preview')
       = t('or')
-      = link_to t('cancel'), admin_pages_url, class: 'alt'
+      = link_to t('cancel'), admin_pages_url(site_id: @site_id), class: 'alt'
     #preview_panel.fullcover.grey_out{:style => 'display: none;'}
       %iframe{:id => 'page-preview', :class => 'fullcover', :name => 'page-preview', :src =>  ActionController::Base.relative_url_root.to_s + '/loading-iframe.html', :frameborder => 0, :scrolling => 'auto'}
       .preview_tools

--- a/app/views/admin/pages/_node.html.haml
+++ b/app/views/admin/pages/_node.html.haml
@@ -7,7 +7,7 @@
             = node_title
           - else
             %i.far.fa-file
-            = (link_to("#{node_title}".html_safe, edit_admin_page_path(page), :title => page.path)).html_safe
+            = (link_to("#{node_title}".html_safe, edit_admin_page_path(page, site_id: page.site_id), :title => page.path)).html_safe
             = page_type
             = spinner
     - node.status_column do

--- a/app/views/admin/pages/_search_result_node.html.haml
+++ b/app/views/admin/pages/_search_result_node.html.haml
@@ -7,7 +7,7 @@
             = node_title
           - else
             %i.far.fa-file
-            = (link_to("#{node_title}".html_safe, edit_admin_page_path(page), :title => page.path)).html_safe
+            = (link_to("#{node_title}".html_safe, edit_admin_page_path(page, site_id: page.site_id), :title => page.path)).html_safe
             = page_type
             = spinner
     - node.path_column do

--- a/config/initializers/trusty_cms_config.rb
+++ b/config/initializers/trusty_cms_config.rb
@@ -88,7 +88,4 @@ Rails.application.reloader.to_prepare do
   if TrustyCms.config_definitions['defaults.snippet.filter'].nil?
     TrustyCms.config.define 'defaults.snippet.filter', select_from: lambda { TextFilter.descendants.map { |s| s.filter_name }.sort }, allow_blank: true
   end
-
-  Admin::LayoutsController.send :helper, MultiSite::SiteChooserHelper
-  Admin::SnippetsController.send :helper, MultiSite::SiteChooserHelper
 end

--- a/config/initializers/trusty_cms_config.rb
+++ b/config/initializers/trusty_cms_config.rb
@@ -88,4 +88,7 @@ Rails.application.reloader.to_prepare do
   if TrustyCms.config_definitions['defaults.snippet.filter'].nil?
     TrustyCms.config.define 'defaults.snippet.filter', select_from: lambda { TextFilter.descendants.map { |s| s.filter_name }.sort }, allow_blank: true
   end
+
+  Admin::LayoutsController.send :helper, MultiSite::SiteChooserHelper
+  Admin::SnippetsController.send :helper, MultiSite::SiteChooserHelper
 end

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.18'.freeze
+  VERSION = '7.0.19'.freeze
 end


### PR DESCRIPTION
### Description
This pull request addresses a security issue wherein users can access page editing if they know a page ID of an unauthorized site, as long as they do not include a `site_id` parameter or utilize a `site_id` parameter the user has permissions for.

This pull request validates that the parameter includes a `site_id` and that the `site_id` matches that of the page, thereby fixing this issue.

The pull request also refactors the `edit` action to reduce complexity and updates the gem version to `7.0.19`.