### PR TITLE
Refactor Site ID Verification to Use Admins Sites Table and Fix Broken Revert Feature by Replacing link_to Helper with button_to

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.20)
+    trusty-cms (7.0.21)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/assets/stylesheets/admin/main.scss
+++ b/app/assets/stylesheets/admin/main.scss
@@ -27,6 +27,7 @@
 @import "partials/preferences";
 @import "partials/treetable";
 @import "partials/login_form";
+@import "partials/previous_versions";
 @import "multi_site_main";
 @import "site_chooser";
 

--- a/app/assets/stylesheets/admin/partials/_previous_versions.scss
+++ b/app/assets/stylesheets/admin/partials/_previous_versions.scss
@@ -1,0 +1,18 @@
+#previous-versions .drawer_handle {
+  padding-top: 0;
+}
+
+#previous-versions h4 {
+  margin-bottom: 0.5em;
+  margin-top: 0;
+  padding-bottom: 0.25em;
+  padding-top: 0;
+}
+
+#previous-versions th {
+  text-align: center;
+}
+
+#previous-versions #no-previous-versions {
+  padding-bottom: 0.5em;
+}

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -87,8 +87,9 @@ class Admin::PagesController < Admin::ResourceController
   end
 
   def verify_site_id
-    @site_id = params[:site_id]&.to_i
-    unless @site_id && @page&.site_id == @site_id
+    page_site_id = @page.site_id
+    user_site_ids = current_user.admins_sites.each.pluck(:site_id)
+    unless user_site_ids.include?(page_site_id)
       redirect_to admin_pages_url
     end
   end

--- a/app/views/admin/pages/_fields.html.haml
+++ b/app/views/admin/pages/_fields.html.haml
@@ -33,9 +33,6 @@
         = render :partial => 'admin/page_parts/page_part', :collection => @page.parts
     = render_region :parts_bottom, :locals => {:f => fields}
 
-#previous-versions
-  = render :partial => 'admin/pages/previous_versions'
-
 .set
   - render_region :layout, :locals => {:f => fields} do |layout|
     - layout.edit_layout do

--- a/app/views/admin/pages/_node.html.haml
+++ b/app/views/admin/pages/_node.html.haml
@@ -7,7 +7,7 @@
             = node_title
           - else
             %i.far.fa-file
-            = (link_to("#{node_title}".html_safe, edit_admin_page_path(page, site_id: page.site_id), :title => page.path)).html_safe
+            = (link_to("#{node_title}".html_safe, edit_admin_page_path(page), :title => page.path)).html_safe
             = page_type
             = spinner
     - node.status_column do

--- a/app/views/admin/pages/_previous_versions.haml
+++ b/app/views/admin/pages/_previous_versions.haml
@@ -1,28 +1,33 @@
-%fieldset
-  %h4
-    %i.fas.fa-clock-rotate-left
-    Previous Versions
-
-  - if @versions.present?
-    %section
-      %table
-        %thead
-          %tr
-            %th Date Updated
-            %th Time Updated
-            %th Updated By
-            %th Action
-        %tbody{ :id => 'versions-table' }
-          - @versions.each do |version|
-            %tr
-              %td= version[:update_date]
-              %td= version[:update_time]
-              %td= version[:updated_by]
-              %td
-                = link_to 'Restore', 
-                  restore_version_admin_page_path(@page.id, version_index: version[:index]),
-                  method: :put,
-                  data: { confirm: 'Are you sure you want to restore this version?' }
-  - else
-    %section
-      %p No previous versions are available.
+#previous-versions
+  %fieldset
+    %h4
+      %i.fas.fa-clock-rotate-left
+      Previous Versions
+    .drawer_contents#versions
+      - if @versions.present?
+        %section
+          %table
+            %thead
+              %tr
+                %th Date Updated
+                %th Time Updated
+                %th Updated By
+                %th Action
+            %tbody{ :id => 'versions-table' }
+              - @versions.each do |version|
+                %tr
+                  %td= version[:update_date]
+                  %td= version[:update_time]
+                  %td= version[:updated_by]
+                  %td
+                    = button_to 'Restore', 
+                      restore_version_admin_page_path(@page, version_index: version[:index]),
+                      method: :put,
+                      data: { confirm: 'Are you sure you want to restore this version?' }
+      - else
+        %section#no-previous-versions
+          %p No previous versions are available.
+    .drawer_handle
+      %a.toggle{:href=>'#versions', :rel=>'toggle[versions]', :class=>"#{(meta_errors? ? 'less' : 'more')}"}
+        = meta_label
+        %i.fas.fa-angle-down

--- a/app/views/admin/pages/_search_result_node.html.haml
+++ b/app/views/admin/pages/_search_result_node.html.haml
@@ -7,7 +7,7 @@
             = node_title
           - else
             %i.far.fa-file
-            = (link_to("#{node_title}".html_safe, edit_admin_page_path(page, site_id: page.site_id), :title => page.path)).html_safe
+            = (link_to("#{node_title}".html_safe, edit_admin_page_path(page), :title => page.path)).html_safe
             = page_type
             = spinner
     - node.path_column do

--- a/app/views/admin/pages/edit.html.haml
+++ b/app/views/admin/pages/edit.html.haml
@@ -6,5 +6,6 @@
   - main.edit_form do
     = form_for @page, :as => :page, :url => admin_page_path(@page), :html => {:method => :put, :multipart => true, :id => 'edit_page', 'data-onsubmit_status'=>t('saving_changes')} do |fields|
       = render :partial => 'fields', :object => fields
+    = render :partial => 'previous_versions'
   - main.edit_popups do
     = render :partial => 'popups'

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.20'.freeze
+  VERSION = '7.0.21'.freeze
 end


### PR DESCRIPTION
### Description
This PR refactors site ID verification by replacing the `site_id` parameter check with a direct lookup in the `admins_sites` table, where user site access is stored.

Additionally, this pull request replaces the `link_to` helper with `button_to` in the Previous Versions partial to ensure the correct HTTP method is used. Previously, `link_to` began forcing a `GET` request, but `button_to` generates a form that submits a `POST` request with "_method"=>"put" that overrides the request method to `PUT` in Rails. To avoid the button forms conflicting with the main page form, the Previous Versions partial is now rendered outside of it.

This pull request also fixes a bug wherein the Save and Continue button was redirecting users to the Content page due to the Save and Continue button missing the `site_id` parameter. The site ID refactor resolves this issue.

Because the site ID verification within the edit page view no longer uses the `site_id` parameter, this was removed in the Content nodes and the Page Search nodes. The `site_id` parameter is still used when selecting a site from the multisite dropdown.

### Testing
**Site ID Verification**

1. In the Admin panel, identify a site and open a page.
2. Copy the page's URL.
3. Navigate to Settings > Users and remove your user’s access to the selected site.
4. Attempt to visit the copied URL. You should be redirected to the content of a permitted site.

**Page Version Revert**

1. Open a page and make a change.
2. In the Previous Versions dropdown, select an earlier version.
3. The page should display the content from the selected previous version, reflecting how it appeared before your edits.

**Save and Continue**

1. Open a page and make a change.
2. Select Save and Continue.
3. You should be redirected back to the edit page view with your changes saved.