### PR TITLE
Publish Scheduled Page if its Published At Date is Today or Earlier

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.21)
+    trusty-cms (7.0.22)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/controllers/page_status_controller.rb
+++ b/app/controllers/page_status_controller.rb
@@ -33,7 +33,9 @@ class PageStatusController < ApplicationController
     pages.each do |page|
       page_id = page.id
       published_at = page.published_at
-      if published_at && published_at <= Time.now
+
+      # Publish the page if its scheduled publish date is today or earlier
+      if published_at && published_at.beginning_of_day <= Time.now
         page.update(status_id: Status[:published].id)
         updated_pages << page_id
       else

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.21'.freeze
+  VERSION = '7.0.22'.freeze
 end


### PR DESCRIPTION
### Reference
Since our page scheduling Lambda function runs once per day, this update ensures that pages are published immediately if their `published_at` date is today or earlier.

The PR also updates `trusty-cms` to version `7.0.22`.