### PR TITLE
Fix Model Save Redirection and Child Slug Error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.24)
+    trusty-cms (7.0.25)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -2,7 +2,6 @@ class Admin::PagesController < Admin::ResourceController
   before_action :initialize_meta_rows_and_buttons, only: %i[new edit create update]
   before_action :count_deleted_pages, only: [:destroy]
   before_action :set_page, only: %i[edit restore]
-  before_action :generate_view_page_url, only: [:edit]
   rescue_from ActiveRecord::RecordInvalid, with: :validation_error
   include Admin::NodeHelper
   include Admin::PagesHelper
@@ -73,10 +72,6 @@ class Admin::PagesController < Admin::ResourceController
 
   def set_page
     @page = Page.find(params[:id])
-  end
-
-  def generate_view_page_url
-    @view_page_url = generate_page_url(request.url, @page)
   end
 
   def set_site_and_homepage

--- a/app/controllers/admin/resource_controller.rb
+++ b/app/controllers/admin/resource_controller.rb
@@ -203,6 +203,7 @@ class Admin::ResourceController < ApplicationController
 
   def redirect_url
     return "#{edit_admin_page_url(model)}?view_page=true" if params[:save_and_view]
+
     params[:continue] ? { action: 'edit', id: model.id } : { action: 'index' }
   end
 

--- a/app/controllers/admin/resource_controller.rb
+++ b/app/controllers/admin/resource_controller.rb
@@ -202,19 +202,8 @@ class Admin::ResourceController < ApplicationController
   end
 
   def redirect_url
-    return edit_admin_page_url(model) if params[:continue]
     return "#{edit_admin_page_url(model)}?view_page=true" if params[:save_and_view]
-
-    admin_pages_url(site_id: model.site.id)
-  end
-
-  def index_page_for_model
-    parts = { action: 'index' }
-    if paginated? && model && i = model_class.all.index(model)
-      p = (i / pagination_parameters[:per_page].to_i) + 1
-      parts[:p] = p if p && p > 1
-    end
-    parts
+    params[:continue] ? { action: 'edit', id: model.id } : { action: 'index' }
   end
 
   def edit_model_path

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -120,7 +120,7 @@ class Page < ActiveRecord::Base
 
   def path
     return '' if slug.blank?
-  
+
     parent? ? parent.child_path(self) : clean_path(slug)
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -119,11 +119,8 @@ class Page < ActiveRecord::Base
   end
 
   def path
-    if parent?
-      parent.child_path(self)
-    else
-      clean_path(slug)
-    end
+    return '' if slug.blank?
+    parent? ? parent.child_path(self) : clean_path(slug)
   end
 
   alias_method :url, :path

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -120,6 +120,7 @@ class Page < ActiveRecord::Base
 
   def path
     return '' if slug.blank?
+  
     parent? ? parent.child_path(self) : clean_path(slug)
   end
 

--- a/app/views/admin/pages/_fields.html.haml
+++ b/app/views/admin/pages/_fields.html.haml
@@ -76,7 +76,7 @@
       = save_model_and_view_page_button(@page)
       = t('or')
       = link_to t('cancel'), admin_pages_url(site_id: @site_id), class: 'alt'
-    #view-page-url-data{ data: { url: @view_page_url } }
+    #view-page-url-data{ data: { url: @page_url } }
   - form_bottom.edit_timestamp do
     = updated_stamp @page
 

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.24'.freeze
+  VERSION = '7.0.25'.freeze
 end


### PR DESCRIPTION
### Description
This pull request addresses the following issues:

- Fixes a `no implicit conversion of nil into String` error related to `child.slug` when creating a new child page. This was occurring due to the `@page.path` method being called when a new page has no slug. This bug was introduced when the **Save and View Draft** feature was added.
- Corrects redirection behavior after clicking the **Save** and **Save and Continue** buttons on models.
- Removes a redundant call to `generate_view_page_url`.

### Additional Changes
Removes the `index_page_for_model` method and replaces its usage with a standard redirect to the model's index page. This change was made due to broken pagination behavior and unreliable page calculations.

### Testing
**New Child Page**

1. Navigate to: https://trustarts.localhost:3000/admin/pages
2. Click **Add Child,** then select **Normal Child** — the new page form should load without errors.
3. Fill in the form and leave the page as **Draft**.
4. Click **Save and View Draft** — you should be redirected to the edit page with the draft open.
5. Click **Save** — you should be redirected back to the **Pages** index.

**Layout**

1. Navigate to: https://trustarts.localhost:3000/admin/layouts
2. Open an existing layout.
3. Click **Save and Continue** — you should remain on the layout edit page.
4. Click **Save** — you should be redirected to the Layouts index.

**Asset**

1. Navigate to: https://trustarts.localhost:3000/admin/assets
2. Open an existing asset.
3. Click **Save and Continue** — you should remain on the same asset edit page.
4. Click **Save** — you should be redirected to the **Assets** index (first page).