### PR TITLE
Add Missing can_view_drafts? Argument and Add trusty-no-cache Parameter to Save and View Draft URL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.25)
+    trusty-cms (7.0.26)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ DEFAULT_PAGE_TYPE_ROUTES = %w[
 ### Save and View Draft Caching
 To ensure that pages and drafts under development are not cached by the browser or content delivery networks (such as CloudFront), the CMS appends a `trusty-no-cache` URL parameter containing the current date and time when a user selects **Save and View Draft** or **Save and View Page**.
 
-Because the `trusty-no-cache` parameter is always unique, it effectively bypasses caching mechanisms at both the CDN and browser levels, ensuring the user receives the most up-to-date version of the content with every request.
+Because the `trusty-no-cache` parameter is always unique, it effectively bypasses caching mechanisms at both the CDN and browser levels, ensuring the user receives the most up-to-date version of the content with every request. Note that additional CDN configuration may be required to ensure query parameters are respected.
 
 ### Page Status Refresh Setup
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ DEFAULT_PAGE_TYPE_ROUTES = %w[
 ].freeze
 ```
 
+### Save and View Draft Caching
+To ensure that pages and drafts under development are not cached by the browser or content delivery networks (such as CloudFront), the CMS appends a `trusty-no-cache` URL parameter containing the current date and time when a user selects **Save and View Draft** or **Save and View Page**.
+
+Because the `trusty-no-cache` parameter is always unique, it effectively bypasses caching mechanisms at both the CDN and browser levels, ensuring the user receives the most up-to-date version of the content with every request.
+
 ### Page Status Refresh Setup
 
 To ensure **Scheduled Pages** automatically update their status to **Published** after their designated **Publish Date & Time**, follow these steps to set up an automated refresh using **AWS Lambda** and **EventBridge**.  

--- a/app/views/admin/pages/_fields.html.haml
+++ b/app/views/admin/pages/_fields.html.haml
@@ -83,13 +83,15 @@
 -# Opens a new tab with the page URL when "Save and View Page" is selected
 :javascript
   document.addEventListener("DOMContentLoaded", function() {
-    let params = new URLSearchParams(window.location.search);
-    let dataDiv = document.getElementById("view-page-url-data");
+    const params = new URLSearchParams(window.location.search);
+    const dataDiv = document.getElementById("view-page-url-data");
+    const baseUrl = dataDiv?.dataset?.url;
 
-    if (params.get("view_page") === "true" && dataDiv) {
-      let newTabUrl = dataDiv.dataset.url;
-      if (newTabUrl) {
-        window.open(newTabUrl, '_blank');
-      }
+    if (params.get("view_page") === "true" && baseUrl) {
+      const now = new Date().toISOString();
+      const separator = baseUrl.includes("?") ? "&" : "?";
+      const newTabUrl = `${baseUrl}${separator}trusty-no-cache=${encodeURIComponent(now)}`;
+      window.open(newTabUrl, '_blank');
     }
   });
+

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.25'.freeze
+  VERSION = '7.0.26'.freeze
 end

--- a/vendor/extensions/layouts-extension/lib/share_layouts/helpers/action_view.rb
+++ b/vendor/extensions/layouts-extension/lib/share_layouts/helpers/action_view.rb
@@ -41,7 +41,7 @@ module ShareLayouts
             end
 
             def can_view_drafts?
-              user_signed_in?
+              user_signed_in? # CMS users can view drafts
             end
           end
         end

--- a/vendor/extensions/layouts-extension/lib/share_layouts/helpers/action_view.rb
+++ b/vendor/extensions/layouts-extension/lib/share_layouts/helpers/action_view.rb
@@ -36,10 +36,13 @@ module ShareLayouts
             end
             
             def find_page
-              page = Page.find_by_path(request.path) rescue nil
+              page = Page.find_by_path(request.path, can_view_drafts?) rescue nil
               page.is_a?(RailsPage) ? page : RailsPage.new(:class_name => "RailsPage")
             end
-            
+
+            def can_view_drafts?
+              user_signed_in?
+            end
           end
         end
       

--- a/vendor/extensions/layouts-extension/lib/share_layouts/helpers/action_view.rb
+++ b/vendor/extensions/layouts-extension/lib/share_layouts/helpers/action_view.rb
@@ -40,6 +40,8 @@ module ShareLayouts
               page.is_a?(RailsPage) ? page : RailsPage.new(:class_name => "RailsPage")
             end
 
+            private
+
             def can_view_drafts?
               user_signed_in? # CMS users can view drafts
             end


### PR DESCRIPTION
### Description - v7.0.26
This pull request introduces two key updates:
1. Adds a `missing can_view_drafts?` method, used as an argument in `Page.find_by_path`, enabling appropriate draft visibility logic.
2. Implements a `trusty-no-cache` URL parameter in the **Save and View Draft** feature to ensure fresh content by bypassing both CloudFront and browser-level caching.