### PR TITLE
Improve Readability of Page.path Method and Move format_path Method to Admin::UrlHelper Module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.26)
+    trusty-cms (7.0.27)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -3,7 +3,6 @@ class Admin::PagesController < Admin::ResourceController
   before_action :count_deleted_pages, only: [:destroy]
   before_action :set_page, only: %i[edit restore]
   rescue_from ActiveRecord::RecordInvalid, with: :validation_error
-  include Admin::NodeHelper
   include Admin::PagesHelper
   include Admin::UrlHelper
 

--- a/app/helpers/admin/node_helper.rb
+++ b/app/helpers/admin/node_helper.rb
@@ -1,6 +1,6 @@
 module Admin::NodeHelper
   include Admin::UrlHelper
-  
+
   def render_nodes(page, starting_index, parent_index = nil, simple = false)
     @rendered_html = ''
     render_node page, starting_index, parent_index, simple

--- a/app/helpers/admin/node_helper.rb
+++ b/app/helpers/admin/node_helper.rb
@@ -1,4 +1,6 @@
 module Admin::NodeHelper
+  include Admin::UrlHelper
+  
   def render_nodes(page, starting_index, parent_index = nil, simple = false)
     @rendered_html = ''
     render_node page, starting_index, parent_index, simple
@@ -23,17 +25,6 @@ module Admin::NodeHelper
       page.extend(*page.menu_renderer_modules)
     end
     page
-  end
-
-  def format_path(path)
-    return '' if path.nil? || path.empty?
-
-    parts = path.split('/').reject(&:empty?)
-    return 'Root' if parts.size == 1
-    return '/' if parts.size == 2
-
-    formatted_path = parts[1..-2].join('/')
-    formatted_path.empty? ? '/' : "/#{formatted_path}"
   end
 
   def homepage

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -1,6 +1,17 @@
 module Admin::UrlHelper
   require 'uri'
 
+  def format_path(path)
+    return '' if path.nil? || path.empty?
+
+    parts = path.split('/').reject(&:empty?)
+    return 'Root' if parts.size == 1
+    return '/' if parts.size == 2
+
+    formatted_path = parts[1..-2].join('/')
+    formatted_path.empty? ? '/' : "/#{formatted_path}"
+  end
+
   def generate_page_url(url, page)
     base_url = extract_base_url(url)
     build_url(base_url, page)

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -6,7 +6,7 @@ module Admin::UrlHelper
 
     parts = path.split('/').reject(&:empty?)
     parts_size = parts.size
-    return 'Root' if parts_size== 1
+    return 'Root' if parts_size == 1
     return '/' if parts_size == 2
 
     formatted_path = parts[1..-2].join('/')

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -2,11 +2,12 @@ module Admin::UrlHelper
   require 'uri'
 
   def format_path(path)
-    return '' if path.nil? || path.empty?
+    return '' if path.to_s.empty?
 
     parts = path.split('/').reject(&:empty?)
-    return 'Root' if parts.size == 1
-    return '/' if parts.size == 2
+    parts_size = parts.size
+    return 'Root' if parts_size== 1
+    return '/' if parts_size == 2
 
     formatted_path = parts[1..-2].join('/')
     formatted_path.empty? ? '/' : "/#{formatted_path}"

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -120,7 +120,7 @@ class Page < ActiveRecord::Base
 
   def path
     return '' if slug.blank?
-  
+
     parent.present? ? clean_path("#{parent.path}/#{slug}") : clean_path(slug)
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -120,8 +120,8 @@ class Page < ActiveRecord::Base
 
   def path
     return '' if slug.blank?
-
-    parent? ? parent.child_path(self) : clean_path(slug)
+  
+    parent.present? ? clean_path("#{parent.path}/#{slug}") : clean_path(slug)
   end
 
   alias_method :url, :path

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.26'.freeze
+  VERSION = '7.0.27'.freeze
 end


### PR DESCRIPTION
### Description -  v7.0.27
This PR improves the readability of the `Page.path` method by refactoring it for clarity and simplifying its recursive logic. Additionally, it moves the `format_path` method into the `Admin::UrlHelper` module for better organization and reuse across the codebase.