### PR TITLE
Add Cache-Control Header to Prevent CloudFront from Caching Set-Cookie Headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.27)
+    trusty-cms (7.0.28)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   before_action :set_standard_body_style, only: %i[new edit update create]
   before_action :set_mailer
   before_action :set_paper_trail_whodunnit
+  before_action :prevent_cookie_cache
 
   attr_accessor :trusty_config, :cache
   attr_reader :pagination_parameters
@@ -67,6 +68,10 @@ class ApplicationController < ActionController::Base
   def set_standard_body_style
     @body_classes ||= []
     @body_classes.concat(%w(reversed))
+  end
+
+  def prevent_cookie_cache
+    response.headers['Cache-Control'] = 'no-cache="Set-Cookie"'
   end
 
   # When using TrustyCms with Ruby 1.9, the strings that come in from forms are ASCII-8BIT encoded.

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.27'.freeze
+  VERSION = '7.0.28'.freeze
 end


### PR DESCRIPTION
### Description - v7.0.28
Added a `before_action` to `ApplicationController` to set the `Cache-Control: no-cache="Set-Cookie"` header on responses. This ensures that CloudFront does not cache and re-serve session cookies across users, which could lead to serious authentication issues.