### PR TITLE
Refactor Page Path Method to Utilize Custom Page Type Routes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.28)
+    trusty-cms (7.0.29)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ TrustyCMS supports a preview feature for standard page types. However, this func
 3. Test the Preview button with each custom page type. If a page type does not preview correctly, remove it from the list.
 
 ### Custom Page Type Routes Setup
-To ensure correct URL generation throughout the application—including in calls to `page.path` and when displaying page URLs in the admin interface—additional configuration is required.
+To ensure correct URL generation throughout the application, including in calls to `page.path` and when displaying page URLs in the admin interface, additional configuration is required.
 
 Create the following initializer: `config/initializers/page_type_routes.rb`
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ TrustyCMS supports a preview feature for standard page types. However, this func
 3. Test the Preview button with each custom page type. If a page type does not preview correctly, remove it from the list.
 
 ### Custom Page Type Routes Setup
-Additional configuration is required to ensure correct URL generation in the admin interface — specifically for the "Edit Page" dropdown and the "Save and View Draft" functionality.
+To ensure correct URL generation throughout the application—including in calls to `page.path` and when displaying page URLs in the admin interface—additional configuration is required.
 
-To enable this, create the following initializer: `config/initializers/page_type_routes.rb`
+Create the following initializer: `config/initializers/page_type_routes.rb`
 
 In this file, define a `CUSTOM_PAGE_TYPE_ROUTES` hash constant that maps custom Page model class names to the corresponding route segments defined in your `config/routes.rb` file. For example, the BlogPage model maps to the route `get 'blog/:slug'`, so its route segment is `'blog'`.
 

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -1,5 +1,7 @@
-module Admin::UrlHelper
-  require 'uri'
+require 'uri'
+
+module Admin::UrlHelper  
+  include UrlHelper
 
   def format_path(path)
     return '' if path.to_s.empty?
@@ -21,7 +23,7 @@ module Admin::UrlHelper
   def build_url(base_url, page)
     return "#{base_url}#{page.path}" if default_route?(page)
 
-    path = lookup_page_path(page)
+    path = lookup_custom_page_path(page)
     return nil unless path
 
     "#{base_url}/#{path}/#{page.slug}"
@@ -34,16 +36,5 @@ module Admin::UrlHelper
     return "#{scheme}://#{host}:#{uri.port}" if host&.include?('localhost')
 
     "#{scheme}://#{host}"
-  end
-
-  def default_route?(page)
-    page_class_name = page.class.name
-    page_class_name == 'Page' || (defined?(DEFAULT_PAGE_TYPE_ROUTES) && DEFAULT_PAGE_TYPE_ROUTES.include?(page_class_name))
-  end
-
-  def lookup_page_path(page)
-    return nil unless defined?(CUSTOM_PAGE_TYPE_ROUTES) && CUSTOM_PAGE_TYPE_ROUTES.is_a?(Hash)
-
-    CUSTOM_PAGE_TYPE_ROUTES[page.class.name.to_sym]
   end
 end

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,4 +1,9 @@
 module UrlHelper
+  def default_path(page)
+    return '' if page.slug.blank?
+    page.parent.present? ? "#{page.parent.path}/#{page.slug}" : page.slug
+  end
+
   def default_route?(page)
     page_class_name = page.class.name
     page_class_name == 'Page' || (defined?(DEFAULT_PAGE_TYPE_ROUTES) && DEFAULT_PAGE_TYPE_ROUTES.include?(page_class_name))

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,12 @@
+module UrlHelper
+  def default_route?(page)
+    page_class_name = page.class.name
+    page_class_name == 'Page' || (defined?(DEFAULT_PAGE_TYPE_ROUTES) && DEFAULT_PAGE_TYPE_ROUTES.include?(page_class_name))
+  end
+
+  def lookup_custom_page_path(page)
+    return nil unless defined?(CUSTOM_PAGE_TYPE_ROUTES) && CUSTOM_PAGE_TYPE_ROUTES.is_a?(Hash)
+
+    CUSTOM_PAGE_TYPE_ROUTES[page.class.name.to_sym]
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -366,12 +366,10 @@ class Page < ActiveRecord::Base
 
   def build_full_path
     if default_route?(self)
-      parent.present? ? "#{parent.path}/#{slug}" : slug
+      default_path(self)
     else
       custom_path = lookup_custom_page_path(self)
-      return nil unless custom_path
-  
-      "#{custom_path}/#{slug}"
+      custom_path ? "#{custom_path}/#{slug}" : default_path(self)
     end
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,6 +2,7 @@ require 'trusty_cms/taggable'
 
 class Page < ActiveRecord::Base
   has_paper_trail
+  include UrlHelper
 
   class MissingRootPageError < StandardError
     def initialize(message = 'Database missing root page')
@@ -120,8 +121,17 @@ class Page < ActiveRecord::Base
 
   def path
     return '' if slug.blank?
-
-    parent.present? ? clean_path("#{parent.path}/#{slug}") : clean_path(slug)
+  
+    if default_route?(self)
+      full_path = parent.present? ? "#{parent.path}/#{slug}" : slug
+    else
+      custom_path = lookup_custom_page_path(self)
+      return '' unless custom_path
+  
+      full_path = "#{custom_path}/#{slug}"
+    end
+  
+    clean_path(full_path)
   end
 
   alias_method :url, :path

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -121,16 +121,10 @@ class Page < ActiveRecord::Base
 
   def path
     return '' if slug.blank?
-  
-    if default_route?(self)
-      full_path = parent.present? ? "#{parent.path}/#{slug}" : slug
-    else
-      custom_path = lookup_custom_page_path(self)
-      return '' unless custom_path
-  
-      full_path = "#{custom_path}/#{slug}"
-    end
-  
+
+    full_path = build_full_path
+    return '' if full_path.blank?
+
     clean_path(full_path)
   end
 
@@ -368,6 +362,17 @@ class Page < ActiveRecord::Base
                      Page.descendant_class(class_name).new.virtual?
                    end
     true
+  end
+
+  def build_full_path
+    if default_route?(self)
+      parent.present? ? "#{parent.path}/#{slug}" : slug
+    else
+      custom_path = lookup_custom_page_path(self)
+      return nil unless custom_path
+  
+      "#{custom_path}/#{slug}"
+    end
   end
 
   def clean_path(path)

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.28'.freeze
+  VERSION = '7.0.29'.freeze
 end


### PR DESCRIPTION
### Description
This pull request fixes a bug where the featured stories section on the blog, which uses the `<r:subnav_two_column />` custom tag, was not resolving the correct URL for custom page types. The issue stemmed from the `page.path` method not accounting for custom routes, causing incorrect links to be rendered. This update ensures that both default and custom routes are handled properly.