### PR TITLE
Fix User Deletion Redirect Error and Add Password Fields to Edit Form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.30)
+    trusty-cms (7.0.31)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -14,6 +14,9 @@
     - form.edit_email do
       = f.label :email, t('email_address') , :class => 'optional'
       = f.text_field 'email', :class => 'textbox', :maxlength => 255
+    
+    - form.edit_password do
+      = render 'password_fields', :f => f
 
     - form.edit_roles do
       - if current_user.admin?

--- a/app/views/admin/users/_password_fields.html.haml
+++ b/app/views/admin/users/_password_fields.html.haml
@@ -1,0 +1,14 @@
+%fieldset#display_password{:style=> (@user.new_record? or !@user.valid?) ? 'display: none' : nil}
+  %label= t('password')
+  %a.button{:href=>'#', :onclick=>"$('#display_password').hide(); $('#change_password').show()"}= t('change')
+%fieldset#change_password{:style=> (!@user.new_record? && @user.valid?) ? 'display: none' : nil}
+  %p
+    = f.label :password, t('new_password')
+    = f.password_field 'password', :value => '', :maxlength => 40, :autocomplete => 'new-password'
+  %p
+    = f.label :password_confirmation, t('password_confirmation')
+    = f.password_field 'password_confirmation', :value => '', :maxlength => 40, :autocomplete => 'new-password'
+    - unless @user.new_record?
+      %span
+        = t('or')
+        %a{:href=>'#', :class=>'cancel-button', :onclick=>" $('#display_password').show(); $('#change_password').hide()"}= t('cancel', class: 'alt')

--- a/lib/trusty_cms/admin_ui.rb
+++ b/lib/trusty_cms/admin_ui.rb
@@ -191,7 +191,7 @@ module TrustyCms
       OpenStruct.new.tap do |user|
         user.preferences = RegionSet.new do |preferences|
           preferences.main.concat %w{edit_header edit_form}
-          preferences.form.concat %w{edit_first_name edit_last_name edit_email}
+          preferences.form.concat %w{edit_first_name edit_last_name edit_email edit_password}
           preferences.form_bottom.concat %w{edit_buttons}
         end
         user.security = RegionSet.new do |security|
@@ -201,7 +201,7 @@ module TrustyCms
         end
         user.edit = RegionSet.new do |edit|
           edit.main.concat %w{edit_header edit_form}
-          edit.form.concat %w{edit_first_name edit_last_name edit_email edit_roles edit_notes}
+          edit.form.concat %w{edit_first_name edit_last_name edit_email edit_password edit_roles edit_notes}
           edit.form_bottom.concat %w{edit_buttons edit_timestamp}
         end
         user.index = RegionSet.new do |index|

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.30'.freeze
+  VERSION = '7.0.31'.freeze
 end

--- a/vendor/extensions/multi-site-extension/lib/multi_site/pages_controller_extensions.rb
+++ b/vendor/extensions/multi-site-extension/lib/multi_site/pages_controller_extensions.rb
@@ -10,7 +10,7 @@ module MultiSite::PagesControllerExtensions
       alias_method :remove, :remove_with_back
       responses.destroy.default do
         session[:came_from] = nil
-        redirect_to admin_pages_url(site_id: model.site.id)
+        redirect_to admin_pages_path
       end
     }
   end


### PR DESCRIPTION
## Description
This pull request addresses two issues:

1. **Fixes a `NoMethodError`** that occurred during redirection after deleting a user.
2. **Adds password fields to the user edit form**, resolving an issue where new users could not be created due to a missing password value.

These changes ensure both the deletion flow and user creation process function as expected.

## Reference
[Issue 937: Deleting users causes error](https://github.com/pgharts/trusty-cms/issues/937)