### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -2,6 +2,9 @@
 # Brakeman is a static analysis security vulnerability scanner for Ruby on Rails applications
 
 name: Brakeman Scan
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/pgharts/trusty-cms/security/code-scanning/37](https://github.com/pgharts/trusty-cms/security/code-scanning/37)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily needs `contents: read` to access the repository's code and `security-events: write` to upload the SARIF file. These permissions will be explicitly defined to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
