### PR TITLE
Implement Hidden Page Status

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.33)
+    trusty-cms (7.0.34)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/models/standard_tags.rb
+++ b/app/models/standard_tags.rb
@@ -103,7 +103,7 @@ module StandardTags
     <pre><code><r:children:each [offset="number"] [limit="number"]
      [by="published_at|updated_at|created_at|slug|title|keywords|description"]
      [order="asc|desc"]
-     [status="draft|reviewed|scheduled|published|all"]
+     [status="draft|reviewed|scheduled|published|hidden|all"]
      [paginated="true"]
      [per_page="number"]
      >

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -32,5 +32,6 @@ class Status
     Status.new(id: 50,  name: 'Reviewed'),
     Status.new(id: 90,  name: 'Scheduled'),
     Status.new(id: 100, name: 'Published'),
+    Status.new(id: 101, name: 'Hidden'),
   ]
 end

--- a/config/locales/en_available_tags.yml
+++ b/config/locales/en_available_tags.yml
@@ -141,7 +141,7 @@ en:
       <pre><code><r:children:each [offset=\"number\"] [limit=\"number\"]
        [by=\"published_at|updated_at|created_at|slug|title|keywords|description\"]
        [order=\"asc|desc\"]
-       [status=\"draft|reviewed|scheduled|published|all\"]
+       [status=\"draft|reviewed|scheduled|published|hidden|all\"]
        [paginated=\"true\"]
        [per_page=\"number\"]
        >

--- a/lib/generators/language_extension/templates/available_tags.yml
+++ b/lib/generators/language_extension/templates/available_tags.yml
@@ -107,7 +107,7 @@
 
       <pre><code><r&#58;children&#58;each [offset="number"] [limit="number"]
        [by="published_at|updated_at|created_at|slug|title|keywords|description"]
-       [order="asc|desc"] [status="draft|reviewed|scheduled|published|all"]>
+       [order="asc|desc"] [status="draft|reviewed|scheduled|published|hidden|all"]>
        ...
       </r&#58;children&#58;each>
       </code></pre>

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.33'.freeze
+  VERSION = '7.0.34'.freeze
 end


### PR DESCRIPTION
## Description - v7.0.34

Users have requested a way to make pages viewable via direct link while excluding them from calendars and page search results. Although TrustyCMS does not include built-in fields on the `Page` model for this purpose, parent applications can now use the `on_hidden_callback` in `TrustyCms::Application` to define custom behavior when a page is marked as hidden.

For example, in `config/initializers/trusty_cms_config.rb`:

```ruby
TrustyCms::Application.config.on_hidden_callback = ->(page) do
  page.display_on_org_calendar = false
  page.display_on_district_calendar = false
  page.hide_from_subnav = true
  page.indexable = false
end
```

This callback enables applications to define what "hidden" means in their own context.

## Testing

1. Using a variety of page types, update the status to **Hidden**.
2. Confirm that the fields specified in your `on_hidden_callback` configuration are correctly updated upon saving the page.
3. Verify that the **Status** column in the Admin Pages view displays **Hidden**.
4. Ensure the page remains viewable via direct link, both when logged in and logged out.

## Reference
[Issue 945: Add Support for "Hidden" Page Status](https://github.com/pgharts/trusty-cms/issues/945)