### PR TITLE
Resolve ActiveSupport::Deprecation Warning Error and Remove Deprecated ActiveStorage::Current.host

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.36)
+    trusty-cms (7.0.37)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -1,9 +1,6 @@
 class Admin::AssetsController < Admin::ResourceController
   paginate_models(per_page: 50)
   COMPRESS_FILE_TYPE = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'].freeze
-  before_action do
-    ActiveStorage::Current.host = request.base_url
-  end
 
   def index
     assets = Asset.order('created_at DESC')

--- a/app/models/standard_tags.rb
+++ b/app/models/standard_tags.rb
@@ -794,7 +794,6 @@ module StandardTags
     tag.expand
     raise TagError.new("`navigation' tag must include a `normal' tag") unless hash.has_key? :normal
 
-    # ActiveSupport::Deprecation.warn("The 'urls' attribute of the r:navigation tag has been deprecated in favour of 'paths'. Please update your site.") if tag.attr['urls']
     result = []
     pairs = (tag.attr['paths'] || tag.attr['urls']).to_s.split('|').map do |pair|
       parts = pair.split(':')
@@ -835,7 +834,6 @@ module StandardTags
   end
   tag 'navigation:path' do |tag|
     hash = tag.locals.navigation
-    # ActiveSupport::Deprecation.warn("The 'r:navigation:url' tag has been deprecated in favour of 'r:navigation:path'. Please update your site.")
     hash[:path]
   end
 

--- a/lib/configuration_extensions/configuration_extensions.rb
+++ b/lib/configuration_extensions/configuration_extensions.rb
@@ -222,13 +222,19 @@ class Rails::Application::Configuration
   # Old extension-dependency mechanism now deprecated
   #
   def extension(ext)
-    ::ActiveSupport::Deprecation.warn("Extension dependencies have been deprecated and are no longer supported in trusty 1.0. Extensions with dependencies should be packaged as gems and use the .gemspec to declare them.", caller)
+    deprecation = ActiveSupport::Deprecation.new('1.0', 'trusty-cms')
+    deprecation.warn(
+      'Extension dependencies have been deprecated and are no longer supported in trusty 1.0. ' +
+      'Extensions with dependencies should be packaged as gems and use the .gemspec to declare them.',
+      caller
+    )
   end
 
-  # Old gem-invogation method now deprecated
+  # Old gem-invocation method now deprecated
   #
-  def gem(name, options = {})
-    ::ActiveSupport::Deprecation.warn("Please declare gem dependencies in your Gemfile (or for an extension, in the .gemspec file).", caller)
+  def gem(name, options = {})    
+    deprecation = ActiveSupport::Deprecation.new()
+    deprecation.warn('Please declare gem dependencies in your Gemfile (or for an extension, in the .gemspec file).', caller)
     super
   end
 

--- a/lib/trusty_cms/admin_ui.rb
+++ b/lib/trusty_cms/admin_ui.rb
@@ -70,8 +70,8 @@ module TrustyCms
       end
 
       def deprecated_add(name, url, caller)
-        ActiveSupport::Deprecation.warn("admin.tabs.add is no longer supported in TrustyCms 0.9.x.  Please update your code to use: \ntab \"Content\" do\n\tadd_item(...)\nend",
-                                        caller)
+        deprecation = ActiveSupport::Deprecation.new('0.9', 'trusty-cms')
+        deprecation.warn('admin.tabs.add is no longer supported in TrustyCms 0.9.x.  Please update your code to use: \ntab \"Content\" do\n\tadd_item(...)\nend', caller)
         NavSubItem.new(name, url)
       end
     end

--- a/lib/trusty_cms/deprecation.rb
+++ b/lib/trusty_cms/deprecation.rb
@@ -2,12 +2,14 @@ require 'active_support'
 
 class AssetType
   def paperclip_processors
-    ActiveSupport::Deprecation.warn('Paperclip processors will be deprecated soon in favor of ActiveStorage.')
+    deprecation = ActiveSupport::Deprecation.new()
+    deprecation.warn('Paperclip processors will be deprecated soon in favor of ActiveStorage.')
 
     active_storage_styles
   end
 
   def paperclip_styles
-    ActiveSupport::Deprecation.warn('Paperclip styles will be deprecated soon in favor of ActiveStorage.')
+    deprecation = ActiveSupport::Deprecation.new()
+    deprecation.warn('Paperclip styles will be deprecated soon in favor of ActiveStorage.')
   end
 end

--- a/lib/trusty_cms/extension_loader.rb
+++ b/lib/trusty_cms/extension_loader.rb
@@ -138,7 +138,8 @@ module TrustyCms
           paths(type)
         end
         define_method("add_#{type}_paths".to_sym) do |additional_paths|
-          ::ActiveSupport::Deprecation.warn("ExtensionLoader.add_#{type}_paths is has been moved and is deprecated. Please use TrustyCms.configuration.add_#{type}_paths", caller)
+          deprecation = ActiveSupport::Deprecation.new('1.0', 'trusty-cms')
+          deprecation.warn("ExtensionLoader.add_#{type}_paths is has been moved and is deprecated. Please use TrustyCms.configuration.add_#{type}_paths", caller)
           initializer.configuration.send("add_#{type}_paths".to_sym, additional_paths)
         end
       end

--- a/lib/trusty_cms/taggable.rb
+++ b/lib/trusty_cms/taggable.rb
@@ -53,7 +53,10 @@ module TrustyCms::Taggable
     message = "Deprecated radius tag <r:#{tag_name}>"
     message << " will be removed or significantly changed in trusty #{options[:deadline]}." if options[:deadline]
     message << " Please use <r:#{options[:substitute]}> instead." if options[:substitute]
-    ActiveSupport::Deprecation.warn(message)
+
+    deprecation_horizon = options[:deadline] || '1.0'
+    deprecation = ActiveSupport::Deprecation.new(deprecation_horizon, 'trusty-cms')
+    deprecation.warn(message)
   end
 
   module ClassMethods

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.36'.freeze
+  VERSION = '7.0.37'.freeze
 end


### PR DESCRIPTION
This pull request focuses on improving the handling of deprecations across the codebase. Key changes include replacing direct calls to `ActiveSupport::Deprecation.warn` with instances of `ActiveSupport::Deprecation`, removing deprecated `ActiveStorage::Current.host`, and removing outdated comments.