### PR TITLE
Add Height / Width attributes for asset tags

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.42)
+    trusty-cms (7.0.43)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/assets/builds/trusty_cms/ckeditor5.js
+++ b/app/assets/builds/trusty_cms/ckeditor5.js
@@ -103083,7 +103083,7 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
         allowWhere: "$text",
         isInline: true,
         isObject: true,
-        allowAttributes: ["id", "size", "alt"]
+        allowAttributes: ["id", "size", "alt", "height", "width"]
       });
     }
     _defineConverters() {
@@ -103100,9 +103100,13 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
           const id = viewElement.getAttribute("id");
           const size = viewElement.getAttribute("size");
           const alt = viewElement.getAttribute("alt");
+          const height = viewElement.getAttribute("height");
+          const width = viewElement.getAttribute("width");
           if (id) attrs.id = id;
           if (size) attrs.size = size;
           if (alt) attrs.alt = alt;
+          if (height) attrs.height = height;
+          if (width) attrs.width = width;
           return writer.createElement("assetImage", attrs);
         }
       });
@@ -103113,9 +103117,13 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
           const id = modelElement.getAttribute("id");
           const size = modelElement.getAttribute("size");
           const alt = modelElement.getAttribute("alt");
+          const height = modelElement.getAttribute("height");
+          const width = modelElement.getAttribute("width");
           if (id) attrs.id = id;
           if (size) attrs.size = size;
           if (alt) attrs.alt = alt;
+          if (height) attrs.height = height;
+          if (width) attrs.width = width;
           return writer.createEmptyElement("r:asset:image", attrs);
         }
       });
@@ -103126,9 +103134,13 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
           const id = modelElement.getAttribute("id");
           const size = modelElement.getAttribute("size");
           const alt = modelElement.getAttribute("alt");
+          const height = modelElement.getAttribute("height");
+          const width = modelElement.getAttribute("width");
           if (id) attrs.id = id;
           if (size) attrs.size = size;
           if (alt) attrs.alt = alt;
+          if (height) attrs.height = height;
+          if (width) attrs.width = width;
           return writer.createContainerElement("r:asset:image", attrs);
         }
       });

--- a/app/javascript/plugins/asset_tags/asset_tag_builder.js
+++ b/app/javascript/plugins/asset_tags/asset_tag_builder.js
@@ -15,7 +15,7 @@ export default class AssetTagBuilder extends Plugin {
             allowWhere: '$text',
             isInline: true,
             isObject: true,
-            allowAttributes: [ 'id', 'size', 'alt' ]
+            allowAttributes: [ 'id', 'size', 'alt', 'height', 'width' ]
         } );
     }
 
@@ -35,10 +35,14 @@ export default class AssetTagBuilder extends Plugin {
                 const id = viewElement.getAttribute( 'id' );
                 const size = viewElement.getAttribute( 'size' );
                 const alt = viewElement.getAttribute( 'alt' );
+                const height = viewElement.getAttribute( 'height' );
+                const width = viewElement.getAttribute( 'width' );
 
                 if ( id ) attrs.id = id;
                 if ( size ) attrs.size = size;
                 if ( alt ) attrs.alt = alt;
+                if ( height ) attrs.height = height;
+                if ( width ) attrs.width = width;
 
                 return writer.createElement( 'assetImage', attrs );
             }
@@ -52,10 +56,14 @@ export default class AssetTagBuilder extends Plugin {
                 const id = modelElement.getAttribute( 'id' );
                 const size = modelElement.getAttribute( 'size' );
                 const alt = modelElement.getAttribute( 'alt' );
+                const height = modelElement.getAttribute( 'height' );
+                const width = modelElement.getAttribute( 'width' );
 
                 if ( id ) attrs.id = id;
                 if ( size ) attrs.size = size;
                 if ( alt ) attrs.alt = alt;
+                if ( height ) attrs.height = height;
+                if ( width ) attrs.width = width;
 
                 return writer.createEmptyElement( 'r:asset:image', attrs );
             }
@@ -69,10 +77,14 @@ export default class AssetTagBuilder extends Plugin {
                 const id = modelElement.getAttribute( 'id' );
                 const size = modelElement.getAttribute( 'size' );
                 const alt = modelElement.getAttribute( 'alt' );
+                const height = modelElement.getAttribute( 'height' );
+                const width = modelElement.getAttribute( 'width' );
 
                 if ( id ) attrs.id = id;
                 if ( size ) attrs.size = size;
                 if ( alt ) attrs.alt = alt;
+                if ( height ) attrs.height = height;
+                if ( width ) attrs.width = width;
 
                 return writer.createContainerElement( 'r:asset:image', attrs );
             }

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.42'.freeze
+  VERSION = '7.0.43'.freeze
 end


### PR DESCRIPTION
This pull request adds support for the `height` and `width` attributes to asset image tags in both the CKEditor 5 build and the custom asset tag builder plugin. These changes ensure that image dimensions can be specified and preserved throughout the editor's conversion pipeline.

### Asset image tag attribute support

* Added `height` and `width` to the allowed attributes for asset image tags in the schema definition in both `ckeditor5.js` and `asset_tag_builder.js`. [[1]](diffhunk://#diff-85a9e19eb050fd6fd3a0edeb9d0309d04b7926d04988606e6a9074db480c67baL103086-R103086) [[2]](diffhunk://#diff-25150b369ca513958f3d14161498f61795ffb35d68c38dbcbb529fcb0212871cL18-R18)

### Conversion pipeline updates

* Updated view-to-model and model-to-view converters to extract and set `height` and `width` attributes when creating asset image elements, ensuring these attributes are retained in all conversion directions. [[1]](diffhunk://#diff-85a9e19eb050fd6fd3a0edeb9d0309d04b7926d04988606e6a9074db480c67baR103103-R103109) [[2]](diffhunk://#diff-85a9e19eb050fd6fd3a0edeb9d0309d04b7926d04988606e6a9074db480c67baR103120-R103126) [[3]](diffhunk://#diff-85a9e19eb050fd6fd3a0edeb9d0309d04b7926d04988606e6a9074db480c67baR103137-R103143) [[4]](diffhunk://#diff-25150b369ca513958f3d14161498f61795ffb35d68c38dbcbb529fcb0212871cR38-R45) [[5]](diffhunk://#diff-25150b369ca513958f3d14161498f61795ffb35d68c38dbcbb529fcb0212871cR59-R66) [[6]](diffhunk://#diff-25150b369ca513958f3d14161498f61795ffb35d68c38dbcbb529fcb0212871cR80-R87)