### PR TITLE
Add `nil` Guard to `format_path` Subpath

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.43)
+    trusty-cms (7.0.44)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -2,15 +2,16 @@ module Admin::UrlHelper
   require 'uri'
 
   def format_path(path)
-    return '' if path.to_s.empty?
+    parts = path.to_s.split('/').reject(&:empty?)
 
-    parts = path.split('/').reject(&:empty?)
-    parts_size = parts.size
-    return 'Root' if parts_size == 1
-    return '/' if parts_size == 2
-
-    formatted_path = parts[1..-2].join('/')
-    formatted_path.empty? ? '/' : "/#{formatted_path}"
+    case parts.size
+    when 0 then ''
+    when 1 then 'Root'
+    when 2 then '/'
+    else
+      subpath = parts[1..-2].to_a.join('/')
+      subpath.empty? ? '/' : "/#{subpath}"
+    end
   end
 
   def generate_page_url(url, page)

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.43'.freeze
+  VERSION = '7.0.44'.freeze
 end


### PR DESCRIPTION
## Description
This pull request fixes a `NoMethodError` that occurs when `parts[1...-2]` returns `nil` in the `format_path` method. This update ensures that `parts[1...-2]` is always an array before calling `.join('/')`, preventing the error.

```ruby
NoMethodError: undefined method `join` for `nil`
formatted_path = parts[1..-2].join('/')
```

## Testing
1. Edit a page in the CMS.
2. Ensure that the path in the dropdown menu is rendering as expected.
3. Check pages in a variety of path depths.

## Reference
[Honeybadger: NoMethodError in admin/pages # edit](https://app.honeybadger.io/projects/46605/faults/125413966)
