### PR TITLE
Update ckeditor asset plugin to fix issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.44)
+    trusty-cms (7.0.45)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/assets/builds/trusty_cms/ckeditor5.js
+++ b/app/assets/builds/trusty_cms/ckeditor5.js
@@ -103072,6 +103072,9 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
 
   // app/javascript/plugins/asset_tags/asset_tag_builder.js
   var AssetTagBuilder = class extends Plugin {
+    static get requires() {
+      return [Widget];
+    }
     init() {
       console.log("AssetTagBuilder plugin initialized");
       this._defineSchema();
@@ -103142,7 +103145,30 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
           if (alt) attrs.alt = alt;
           if (height) attrs.height = height;
           if (width) attrs.width = width;
-          return writer.createContainerElement("span", attrs);
+          const container = writer.createContainerElement("span", {
+            class: "asset-image-tag",
+            "data-asset-id": id,
+            "data-asset-size": size
+          });
+          const label = writer.createUIElement(
+            "span",
+            { class: "asset-image-tag__label" },
+            function(domDocument) {
+              const domEl = this.toDomElement(domDocument);
+              const parts = [
+                "Asset image",
+                id ? `#${id}` : "",
+                size ? `(${size})` : "",
+                alt ? `\u2014 ${alt}` : "",
+                height ? `height: ${height}` : "",
+                width ? `width: ${width}` : ""
+              ].filter(Boolean);
+              domEl.textContent = parts.join(" ");
+              return domEl;
+            }
+          );
+          writer.insert(writer.createPositionAt(container, 0), label);
+          return toWidget(container, writer, { label: `Asset image ${id ? `#${id}` : ""}` });
         }
       });
     }
@@ -103257,7 +103283,6 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
         "code",
         "removeFormat",
         "|",
-        "specialCharacters",
         "horizontalLine",
         "link",
         "bookmark",

--- a/app/assets/builds/trusty_cms/ckeditor5.js
+++ b/app/assets/builds/trusty_cms/ckeditor5.js
@@ -103076,6 +103076,7 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
       console.log("AssetTagBuilder plugin initialized");
       this._defineSchema();
       this._defineConverters();
+      this._defineDataNormalization();
     }
     _defineSchema() {
       const schema = this.editor.model.schema;
@@ -103124,7 +103125,7 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
           if (alt) attrs.alt = alt;
           if (height) attrs.height = height;
           if (width) attrs.width = width;
-          return writer.createEmptyElement("r:asset:image", attrs);
+          return writer.createContainerElement("r:asset:image", attrs);
         }
       });
       editingDowncast.elementToElement({
@@ -103141,9 +103142,40 @@ Original error: ${originalError.name}: ${originalError.message}` : "";
           if (alt) attrs.alt = alt;
           if (height) attrs.height = height;
           if (width) attrs.width = width;
-          return writer.createContainerElement("r:asset:image", attrs);
+          return writer.createContainerElement("span", attrs);
         }
       });
+    }
+    _defineDataNormalization() {
+      const editor = this.editor;
+      const processor = editor.data.processor;
+      const originalToView = processor.toView.bind(processor);
+      const originalToData = processor.toData.bind(processor);
+      processor.toView = (data) => {
+        let normalized = data;
+        normalized = normalized.replace(
+          /<r:asset:image\b([^>]*?)\/>/gi,
+          "<r:asset:image$1></r:asset:image>"
+        );
+        normalized = normalized.replace(
+          /<r:asset:image\b([^>]*?)>(?!\s*<\/r:asset:image>)/gi,
+          "<r:asset:image$1></r:asset:image>"
+        );
+        return originalToView(normalized);
+      };
+      processor.toData = (viewFragment) => {
+        const html2 = originalToData(viewFragment);
+        return html2.replace(
+          /<r:asset:image\b([^>]*?)>([\s\S]*?)<\/r:asset:image>/gi,
+          (match, attrs, inner) => {
+            const cleanedInner = inner.replace(
+              /^(?:\s|&nbsp;|&#160;)+|(?:\s|&nbsp;|&#160;)+$/g,
+              ""
+            );
+            return `<r:asset:image${attrs} />${cleanedInner}`;
+          }
+        );
+      };
     }
   };
 

--- a/app/assets/stylesheets/admin/assets.scss
+++ b/app/assets/stylesheets/admin/assets.scss
@@ -1,3 +1,19 @@
+.ck-content .asset-image-tag {
+  background-color: #dcdcdc;
+  display: inline-flex;
+  align-items: center;
+  padding: 1em;
+  border: 1px dashed #c3c3c3;
+  opacity: 0.85;
+  user-select: none;
+}
+
+.ck-content  .asset-image-tag__label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85em;
+  white-space: nowrap;
+}
+
 .search {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/app/javascript/plugins/asset_tags/asset_tag_builder.js
+++ b/app/javascript/plugins/asset_tags/asset_tag_builder.js
@@ -1,6 +1,10 @@
-import { Plugin, toWidget } from 'ckeditor5';
+import { Plugin, Widget, toWidget } from 'ckeditor5';
 
 export default class AssetTagBuilder extends Plugin {
+      static get requires() {
+        return [ Widget ];
+      }
+
     init() {
         console.log( 'AssetTagBuilder plugin initialized' );
         // Plugin logic goes here
@@ -49,6 +53,7 @@ export default class AssetTagBuilder extends Plugin {
             }
         } );
 
+    
         // Data downcast: ensure no inner whitespace like &nbsp; gets serialized.
         dataDowncast.elementToElement( {
             model: 'assetImage',
@@ -87,7 +92,33 @@ export default class AssetTagBuilder extends Plugin {
                 if ( height ) attrs.height = height;
                 if ( width ) attrs.width = width;
 
-                return writer.createContainerElement( 'span', attrs );
+                const container = writer.createContainerElement('span', {
+                    class: 'asset-image-tag',
+                    'data-asset-id': id,
+                    'data-asset-size': size
+                });
+
+                const label = writer.createUIElement(
+                    'span',
+                    { class: 'asset-image-tag__label' },
+                    function (domDocument) {
+                        const domEl = this.toDomElement(domDocument);
+                        const parts = [
+                        'Asset image',
+                        id ? `#${id}` : '',
+                        size ? `(${size})` : '',
+                        alt ? `— ${alt}` : '',
+                        height ? `height: ${height}` : '',
+                        width ? `width: ${width}` : ''
+                        ].filter(Boolean);
+
+                        domEl.textContent = parts.join(' ');
+                        return domEl;
+                    }
+                );
+
+                writer.insert(writer.createPositionAt(container, 0), label);
+                return toWidget(container, writer, { label: `Asset image ${id ? `#${id}` : ''}` });
             }            
         } );       
 

--- a/app/javascript/trusty_cms/ckeditor5.js
+++ b/app/javascript/trusty_cms/ckeditor5.js
@@ -145,7 +145,6 @@ const editorConfig = {
             'code',
             'removeFormat',
             '|',
-            'specialCharacters',
             'horizontalLine',
             'link',
             'bookmark',

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.44'.freeze
+  VERSION = '7.0.45'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "esbuild app/javascript/trusty_cms/ckeditor5.js --bundle --sourcemap --outdir=app/assets/builds/trusty_cms --public-path=/assets",
+    "build": "esbuild app/javascript/trusty_cms/ckeditor5.js --bundle --sourcemap --outdir=app/assets/builds/trusty_cms --public-path=/assets --loader:.svg=text",
     "build:watch": "npm run build -- --watch"
   },
   "keywords": [],


### PR DESCRIPTION
This pull request updates the `AssetTagBuilder` CKEditor 5 plugin to improve how custom `r:asset:image` tags are handled in both the editor's data model and its HTML output. The main focus is on normalizing the tag structure to ensure consistent handling of self-closing and paired tags, as well as updating the way these tags are rendered in the editor.

**Asset Tag Normalization and Conversion Improvements:**

* Added a `_defineDataNormalization` method to ensure that all `<r:asset:image>` tags are normalized to paired tags when loading into the editor, and converted back to self-closing tags (with whitespace cleanup) when exporting data. This helps avoid inconsistencies between self-closing and paired tag formats. (F0951dbcL87, [app/assets/builds/trusty_cms/ckeditor5.jsL103144-R103179](diffhunk://#diff-85a9e19eb050fd6fd3a0edeb9d0309d04b7926d04988606e6a9074db480c67baL103144-R103179))
* Updated the upcast converter to use `writer.createContainerElement('r:asset:image', attrs)` instead of `createEmptyElement`, ensuring the tag is always treated as a container in the model. [[1]](diffhunk://#diff-25150b369ca513958f3d14161498f61795ffb35d68c38dbcbb529fcb0212871cL68-R69) [[2]](diffhunk://#diff-85a9e19eb050fd6fd3a0edeb9d0309d04b7926d04988606e6a9074db480c67baL103127-R103128)
* Remove special characters from the menu bar
* Add CSS to show a placeholder for asset tags on the front end of the editor. 
**Plugin Initialization:**

* Registered the new normalization logic in the plugin's `init` method, so it's always applied when the plugin is loaded. [[1]](diffhunk://#diff-25150b369ca513958f3d14161498f61795ffb35d68c38dbcbb529fcb0212871cL1-R9) [[2]](diffhunk://#diff-85a9e19eb050fd6fd3a0edeb9d0309d04b7926d04988606e6a9074db480c67baR103079)

These changes make the handling of custom asset tags more robust and consistent, reducing the risk of malformed HTML or unexpected editor behavior. Reducing the risk of overwriting content in the editor view, which overwrites the content on saving.