### PR TITLE
CKEditor5.css failing precompiles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.46)
+    trusty-cms (7.0.47)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/app/assets/config/trusty-cms-manifest.js
+++ b/app/assets/config/trusty-cms-manifest.js
@@ -6,4 +6,3 @@
 //= link admin/custom_file_upload.js
 //= link admin/validations/scheduled_status_validation.js
 //= link trusty_cms/ckeditor5.js
-//= link trusty_cms/ckeditor5.css

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.46'.freeze
+  VERSION = '7.0.47'.freeze
 end


### PR DESCRIPTION
This pull request includes a minor update to the asset manifest and a version bump for the TrustyCms gem.

*Version update:*

* Updated the gem version in `lib/trusty_cms/version.rb` from `7.0.46` to `7.0.47`.

*Asset manifest adjustment:*

* Removed the reference to `trusty_cms/ckeditor5.css` from `app/assets/config/trusty-cms-manifest.js`.