### PR TITLE
Upgrade ckeditor and gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.0.48)
+    trusty-cms (7.0.49)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.0.48'.freeze
+  VERSION = '7.0.49'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "blueimp-file-upload": "^10.32.0",
-    "ckeditor5": "46.0.3",
+    "ckeditor5": "^47.6.0",
     "jquery": "^3.6.1",
     "jquery-treetable": "^3.2.0-1",
     "jquery-ui": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "blueimp-file-upload": "^10.32.0",
-    "ckeditor5": "^47.6.0",
+    "ckeditor5": "47.6.0",
     "jquery": "^3.6.1",
     "jquery-treetable": "^3.2.0-1",
     "jquery-ui": "^1.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,471 +141,475 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
-"@ckeditor/ckeditor5-adapter-ckfinder@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-46.0.3.tgz#f19f9fa1a0a33aa2fa502f0f7c779c027f4f78bd"
-  integrity sha512-xebONgXYuF8Fuhr6C+lpwRSfpChSrJKTy5S0i7vuBY+EeuXLRED7AuCOvPwV9oed1/CqbzDWWH1IefgkLwZwvQ==
+"@ckeditor/ckeditor5-adapter-ckfinder@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.6.0.tgz#50bc924ddb4a03e7ad2611af5afc424c910c9948"
+  integrity sha512-SMGuLMvXlNK9NjKL24zjV1JK3KCQxMoafTFEW5iGiKA63g9GNmhVhpu56dT+9bRpOzDNchnSYW9ljuW04bDr4g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-upload" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-upload" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-alignment@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-46.0.3.tgz#34cb75002fefc79dbffc94b08c0a0a34e722adb5"
-  integrity sha512-P0qegTFO9u5gbR7Ig/JI0vGdWFtxzM08KPCbeYTpQtdI9+DrKdvWFo0LVB7LJjR6OKuUPCtnulGgCyhuzNT7lw==
+"@ckeditor/ckeditor5-alignment@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.6.0.tgz#97285531923a7d0ef9d24558c3d012b7420af353"
+  integrity sha512-vfu+Hsza8kW0ehf+7N1hibmWRQpJ84CTPWjM9PNtwb+irvnQ3WjAK8D0fw9dY+ZM7FtPCT9xJGCDCI5MoRZ/fA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-autoformat@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-46.0.3.tgz#ac2390550211aa71b7065559d4d9c135e3296ad0"
-  integrity sha512-E3bjlf8HbTD9FiGHPQyrbRXniA7W06CecmlKXwHDisGC8lLLF8ZpuRX4oGAH5QLpSVFyGuj0C1GJtVY0+PEjOw==
+"@ckeditor/ckeditor5-autoformat@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.6.0.tgz#08ccfa310115a5a392ac9213438db37fb20202dd"
+  integrity sha512-idBf0RsdKr1sIcaupIqHksx6VPzGtCsKi4ZjAfFl4syVCvx3lPpJselkkvsdpTmw0Rqg4x8zyfMGElSL82SXuA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-heading" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-heading" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-autosave@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-46.0.3.tgz#d26d0157ebf4005fac8f802de16ce65188e64c92"
-  integrity sha512-SStt6opEniy0i5N5QMsAttpxhPvlmQ5UgmfvVmkyBnvOGwFwSmIFjxAXdTsAhvKdDaKrsjeCpv/j6L6llYk7dw==
+"@ckeditor/ckeditor5-autosave@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.6.0.tgz#77e91267abd1eeb7ff31b124d06c7be6a1dc8294"
+  integrity sha512-bU7E14bu/8paefBMtOT61P5V95fdafaG3OQXdnE5tHD7jrualznuEzek519U5VzL8Gh1Wo4cHyLA2pg1Ljyb/A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-basic-styles@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-46.0.3.tgz#563cb4ef19ecfd763745cb0bd79940fd03b7a81c"
-  integrity sha512-THmEPEbYopSfq8NTAugPLk+QW8/vuRkJfg/NpESzeugqCkBG2to3thOHdetbpye4IJBokLFhLsGFfKVYfVF81A==
+"@ckeditor/ckeditor5-basic-styles@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.6.0.tgz#d0ec52ae4eb17b8e535998a7af9af4cfb56ce117"
+  integrity sha512-GYYO//eNp13ZGn7Fg7s9eSdaDLt/Hut6efC8gTkakfx2yCZqcjzjV4gBJmvaIul1hw+EzsMjBhYe4lorBAM5oA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-block-quote@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-46.0.3.tgz#79a783d36ad4f9163cc31fb608ac6213c040a145"
-  integrity sha512-8bI7GoxOPrIExt/32gxLDQJB5VdSp3Oi6fqA+GH0Lqj+ri8HKfl3S147GymTUfBh01IOymQNL7xX04Dq1Nbl6A==
+"@ckeditor/ckeditor5-block-quote@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.6.0.tgz#2181daad92548af74abd139b4e9028a6edf4372f"
+  integrity sha512-xFydZ2+1tcv5TcqoWPtlDJ0wntujOJfIrXncqDe6wXXe/ByK5/wJu2d88XxLQFCNvn3BjP9VLBQNrKIAlpFM1A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-enter" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-enter" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-bookmark@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-46.0.3.tgz#f597408d87746105ba5d7a80ce8a7f4fa32a7cb6"
-  integrity sha512-f1usHplw2Ndhm1AiyjWfOWoaSQehMqBaXTa94OXlvO6ci1RIijdFm+DKn4Lgh/vSjv4vo25eQReTmEM0KaysvA==
+"@ckeditor/ckeditor5-bookmark@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.6.0.tgz#14b93f34c8c1c13e11ee78ab634f464909a04f56"
+  integrity sha512-Bkxh46mHCEYM9cOSJjK6NpHtBpSyJWqYVyTrLl24SiixtHUpuXqFKKM7Jo23GjcuPBXVSdG2ax6iwUCzcFuHAg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-link" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-link" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-ckbox@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-46.0.3.tgz#e0999969662c56bc768ac0ee7a4b09a3f6fefb82"
-  integrity sha512-UnmCqOU/iyYDef/OVsWbixeXwo+0pb3YGNWgmd2YsCFUUerbpOkDwwGuvCZPE7Hs34lNz8ybbhjR9KmGu8WcAw==
+"@ckeditor/ckeditor5-ckbox@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.6.0.tgz#0a60e5e9e2de5b6e9b7ccc8f5da93d00d66e0ab1"
+  integrity sha512-IOpJZMc8NLe4ruLfG8jfwC84yEbTqn/0rUyKgdmTf6M5ZofpIMyaqSIU30aULBgmaXwkE/hQTbfjgaJ3UUSo5g==
   dependencies:
-    "@ckeditor/ckeditor5-cloud-services" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-image" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-upload" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-cloud-services" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-image" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-upload" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
     blurhash "2.0.5"
-    ckeditor5 "46.0.3"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-ckfinder@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-46.0.3.tgz#f7a0c234be03f71229461668dc8a659f608ecdca"
-  integrity sha512-VXggqo2w0TgFPyu6z+uH3aTWQMhbq2F2iPUi8SreYCL0JclczbU4HDKqzQU+RKhrzp+yhK1n7ztX5aN1H9EVAw==
+"@ckeditor/ckeditor5-ckfinder@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.6.0.tgz#f719050a84a0b7c11b8ee968c351b948417fda93"
+  integrity sha512-hCuFkKx/ph5ntmCSvjO7zIxET/pL/5Q1fYt1joOE9hjaBWFMoRao87GUjJ3O751ZAkioSe90zECP8SXYz8ZlIQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-image" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-image" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-clipboard@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-46.0.3.tgz#5a42799228875a8112c98fc61ad1ca050f42fca0"
-  integrity sha512-ECz2goSbYZSlhRT2HszIPCMWFfThA0uIuXpI5PjYj7rDJUoip/Y3/UZjyMo47IUFf66Y4VdvJoq0fv/Z86HYIg==
+"@ckeditor/ckeditor5-clipboard@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.6.0.tgz#95c2498e5b3dc688d71184bda176863963449d00"
+  integrity sha512-ymkOH+O9C+v3vKTaw1iOrlJMti+7Q9ycKdP5bCc9/4ywtR6cRtZ5BnEkbK1S1CSxkijQCdpe+0tNgXI2aniD+A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-cloud-services@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-46.0.3.tgz#7c02822ed77a1b4d3e80c0f70b4b250c5e946945"
-  integrity sha512-eKmtcygKoAoba6LGKdsFQyU50yZeeFgD9k05HYnN4BZCqZjrmlTbo3mQrTREgM/w2yxQ4AkDVj162S9NOyibWA==
+"@ckeditor/ckeditor5-cloud-services@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.6.0.tgz#ba89532529c1ea856925b305b963331e72290241"
+  integrity sha512-8MkrqbfiglNwqkUnfL0uoBZVlHmsqvq6wXiz60fnWTpTiEmxzV95/JeT7toFafvxLO7WSzBjEcZcmc9Z6ChyAw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-code-block@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-46.0.3.tgz#a8595063ce34da2a2095e89cf79be8b0532de056"
-  integrity sha512-5Bny1t2jb+Fruy4Tf0Es6YGPe24eWUiCskTv7QZkebEUtectUhZXjrbAPXkn9GQH9E+jU/ywhYkkCKwDgg+Vnw==
+"@ckeditor/ckeditor5-code-block@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.6.0.tgz#6846c66a155807dbfb97f58afc5bac3736583e2a"
+  integrity sha512-SetV7GnNwUOqyaPHlzXgTuT/TrLLhQ9z3glmfIQ4A9BvV9dvP6Nb9vFeJnDHuhEwBauQS8M0DqdFc+F3qdJwsg==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-enter" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-enter" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-core@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz#e9d294b517f646d6efdccecc8b3dc030feac7641"
-  integrity sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==
+"@ckeditor/ckeditor5-core@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.6.0.tgz#0df87dc3294b4b91419aa064b414fbc0462827ea"
+  integrity sha512-kw1zN6Fv5SRiZBSCfJV8yBGmirNC+vnKBOKxiS5I50wRReH90IJnTyh5Fu/vqsmr7UtSR5xvAKhu4xg30MrsRQ==
   dependencies:
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-watchdog" "46.0.3"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-watchdog" "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-easy-image@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-46.0.3.tgz#fbf72ea4524ded6b5aceacc41fa6f5e08672f7f3"
-  integrity sha512-UZs1G2wZaUr4lJSUsECBpM5ntr0UIXhGYG6lhE4Lf1TBaOypzxusR0H3txNtWIX1rq6hCeFH1P7meijfvJRgbw==
+"@ckeditor/ckeditor5-easy-image@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.6.0.tgz#7d168f6ccd0adc079435643fb24c6452cf29dca4"
+  integrity sha512-hOTxDnCU+d3vp0eKeULQxk3rZRkkZ551OM9O1ZE9sEaOjAdndaikqSH9VEwhSKTfmRIWHrMJg1ouxw2aeHvwHw==
   dependencies:
-    "@ckeditor/ckeditor5-cloud-services" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-upload" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-cloud-services" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-upload" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-editor-balloon@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-46.0.3.tgz#35382c0393babc1a5f3ec8acd9a0f68ebb56a291"
-  integrity sha512-NXqmQK45DybJmgWFUln2uTvWqg77BuTp/R/4F33K6fgA4QGmnlWZ+l96Z5Rpmq6Rxc7suBNIKKWRFihquHw1hw==
+"@ckeditor/ckeditor5-editor-balloon@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.6.0.tgz#4fc068f9981cdb416e825fafb1ebf167b854aee7"
+  integrity sha512-LsnDsovjVrif7mRbdwFJKmKI5q5xmD2Zi/8+ImsCUm6fOo9Q3nmairDoWhQ0Bm1KH1MFDFYCDzZXuiI42T2F8g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-editor-classic@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-46.0.3.tgz#f872b541014dc24b3a3ff62331a785348ea3ae40"
-  integrity sha512-fw4pdBqT1UpVYkBBpACQn9w5iR2Y62AvGW7ANt6b1nv55+FIN0uEAHsuChvZdFra8iJQR1qyilT24LVOTtk5mg==
+"@ckeditor/ckeditor5-editor-classic@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.6.0.tgz#0edcf4a104578164488bac91f3b22ef6e0145650"
+  integrity sha512-NF+YBnfacILu3+EvsEb5UZvE9llpcO0qfbDdxJUu+t8bHXMhZzo3kOh0Gw3mB3Yil62IVTita0P3AZvzq053zw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-editor-decoupled@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-46.0.3.tgz#dae17ccb2d3fc3461fbe174b45590f9cde8748be"
-  integrity sha512-svrTpgGCi9YLhzit97i+A+lVStnQ4fNbGj6O1HlRG676BA20zqUkUWbNDPlBQT5sbq4N2oLKPwBmAqtUsF9ivQ==
+"@ckeditor/ckeditor5-editor-decoupled@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.6.0.tgz#f87ec232fc5b92fc9f43e0e57d55e1bae75bc95e"
+  integrity sha512-BgwJZUJEzR06bLf1Qk6Klilaacumk4uMZCAdQCCg4LSMNAk3eaQgccl6SUZqUH9V/NDpogIGcaDbUPWvuxJKjQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-editor-inline@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-46.0.3.tgz#31342902ec3ad3185cfaf8097d55f1086f8f63a6"
-  integrity sha512-VfsD95gALQrUMHRJ5f2KKIPgtRb5flAqug85GSWy+wJZXOv7dC953tc1v8PYtUOHV6R3k2SWOUAGUClRu2ijOQ==
+"@ckeditor/ckeditor5-editor-inline@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.6.0.tgz#3d515bab5137fdca3b2ca135b6af0eb56088eaa9"
+  integrity sha512-89B+SYsuI64mfu/qtIyYarw0qSmripIA33L3FaH6KUJpPBwwIjd5huZg6L5BXE6ZuPMGyRjRq6JapQb0zExWEQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-editor-multi-root@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-46.0.3.tgz#b9d9b4f62d5396e3597c24f6183ab92ea0512d52"
-  integrity sha512-mS9gd8zTCclstU5DROT5L3sVq6HSDk0jw/7d7bgKEvWbGvQ6iPiqcgZ+bzpyrtvXMQKnmgfytZpU9qfODLpwFA==
+"@ckeditor/ckeditor5-editor-multi-root@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.6.0.tgz#3c6e07e347c52095206528cc097f1a41938a0834"
+  integrity sha512-uA5JPlV7QFfMVErqoVdwLJbUoF/u3X3GGg5s+VMeVoVTnn3ZQ8592HVftuT87HIiI8W1NHdlrE/32+3iTnOoVA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-emoji@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-46.0.3.tgz#e129445b3a078b19268482b55dd769449922d636"
-  integrity sha512-XiQsDeIZdSRDuFz/eoH16L21+Ucxykt+qHvqHSXB6bnVE8A3+65fxXYXicXnlb8st6UYhVBGwd53cpRz1ljMww==
+"@ckeditor/ckeditor5-emoji@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.6.0.tgz#36c230ef55aafedb1f777273aab03531165303c2"
+  integrity sha512-DLoScPQAMKXpe6U3M6Dw2sed0ElQeMgun0B/j//EfBPdtqkY3IDPg/R7SlRxsYuYNf0cEWNZwaNnlL/JI6w+gA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-mention" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-mention" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
     fuzzysort "3.1.0"
 
-"@ckeditor/ckeditor5-engine@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz#a4d740ad4cd87aa5c2dedbf45bc60f8cad8f4823"
-  integrity sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==
+"@ckeditor/ckeditor5-engine@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.6.0.tgz#98d8d6bec6292668695ba653f1818b63abbfd347"
+  integrity sha512-HjtlviZZhPDSfHS7aEYUfhVuEWCHCyjCUDd4r4vx9A+02W7G+Gg6I0lqtDqTRL/Bp5rVv3MeRrcaYU21jCFJ3Q==
   dependencies:
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-enter@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-46.0.3.tgz#d511f822b98644c8c3d614930184c7df845083c3"
-  integrity sha512-Z/IVe2Bn/PXamXxTlG9Pf/4K1OoGsNpwBfdywiqSYxdlF5E/4e5xArCKuFVkLGPO2YPSXShPhucBorqHlGQI2Q==
+"@ckeditor/ckeditor5-enter@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.6.0.tgz#187d1a59422e86bd3af2cc9369095bfc4d9d84cd"
+  integrity sha512-+WlxCGj4J+Q+BFyAWkJZ6q+t4LnDHEstQtYFT5pGj23oUSVeOBzc+7e5FqU4LLtOzYnClN7t98OGPDPOHHhS9w==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
 
-"@ckeditor/ckeditor5-essentials@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-46.0.3.tgz#56a0b982fe52c8ba605773cfb2c3f0f901849bb3"
-  integrity sha512-lUk+AkDVXb0YXEbyw+14sA5vFtXoWA4i6026tyN8I9uShMIyyjzkVUtTX9a0AWp5j//sJ5Ke+wMS0QUFRDtj+Q==
+"@ckeditor/ckeditor5-essentials@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.6.0.tgz#9d0d8884ddac3e39f20044d845afb3301f2a3af9"
+  integrity sha512-rI5/FWOcMjGVtWlHisBQCtL88pCZJiB+SwpmpumdALqP99urUqbL8tFprwyv95r7o4sFPMymJYVdHGlUjKb4Dw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-enter" "46.0.3"
-    "@ckeditor/ckeditor5-select-all" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-undo" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-enter" "47.6.0"
+    "@ckeditor/ckeditor5-select-all" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-undo" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-find-and-replace@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-46.0.3.tgz#c2b4b617ea0c5009d5bbf5366865c52ed7721eab"
-  integrity sha512-WKJ32slfJKPE2xnOWtk8/kqaDlUE3AKXChmRw6fPXM9pRpBRItLrbMO4Lhic9F1V8UzzY88/6VMuTMUlVg7/pQ==
+"@ckeditor/ckeditor5-find-and-replace@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.6.0.tgz#cf69a867e896101bea3075964bbd9cc38aa16ead"
+  integrity sha512-S6E6zgO3T4A5rFC3Idr7DvhD2QEov2yIrWVbkIFTc0Q4fuvuNIxoke59fvc+SYd9BeDvQawP7a3RjMBTgvVRGA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-font@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-font/-/ckeditor5-font-46.0.3.tgz#2d7e6d27f6cc0841029fca64224ebeebd46963f7"
-  integrity sha512-4A0F3ShSn5QE0aQVus45EiIpFntJdXQnlf/kCLbQstYBUof915vReCa/c0cRu8q+1GOB9DmTarSPfb2jxDKhaA==
+"@ckeditor/ckeditor5-font@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.6.0.tgz#28914be860c57e0fc950c61ab65fb2f3105b28bb"
+  integrity sha512-MZ9nUVCF+H+uYZeEy2FRlRys4kUFhuFcTJSaVNh6+obC8p9yrdRk9sSIKzH3VfJwmY9RWwEGg5udcyuQ4QT7KQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-fullscreen@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-46.0.3.tgz#aaca7671cd65864924a23ac25a41990d1a0d5f31"
-  integrity sha512-+AjKdmknSeihgVytx2CZPvqJ8Iv0sQd8kP1AvTMsp7JWr9kP3eMZEWJ3IwUP7GaH9O+cSDqeW2pFY4rW1ajYlQ==
+"@ckeditor/ckeditor5-fullscreen@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.6.0.tgz#3fdaaa584d71f9e4abbde98f1f284c6e27dd8bef"
+  integrity sha512-M53UtSJ5jLNwt34iqllHeW2zT7HEpZwzSWX/TLn/3Q4d95m9+HAO4vBHDkuX+wd2KTl+8MYcrXYSCNWDqWzU/A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-editor-classic" "46.0.3"
-    "@ckeditor/ckeditor5-editor-decoupled" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-editor-classic" "47.6.0"
+    "@ckeditor/ckeditor5-editor-decoupled" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-heading@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-46.0.3.tgz#5d90467e9e4f082d8c8ec1dc3b31474b74e0c320"
-  integrity sha512-FKTgc1I9nDvnoDJ6RzkmPX7knhU3k6iH8IGUngH78TIOmhcWPVzv7Sftszos/LdX+kTc1ZoWWaHo5vrk90waZg==
+"@ckeditor/ckeditor5-heading@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.6.0.tgz#86a7727c1c360a4c2c011f28cfc0d2366a306b0a"
+  integrity sha512-hduHYHzcY3j+K4e2O6A72ksH16I885zWjydwFOCGXnIPUTZAL9ZZLwRuhqDQ6jZ8uNPqiXcuRpZd1tFIXbKXOg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-paragraph" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-paragraph" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-highlight@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-46.0.3.tgz#c75991f017a039a500bec66e17e8a07ed8a44533"
-  integrity sha512-woO40tvOomrE7PHV/LAIOuNDb6sm2xiRQpT3r6TU1bvHZWSdt+hBCVRbnPxMNY2b/+0FGeV6cIOP8jlZ6JXF2g==
+"@ckeditor/ckeditor5-highlight@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.6.0.tgz#408fda9a52e1ec29e1f7521e1833c75b81b02140"
+  integrity sha512-YXZWN6nIyVBrVvsYXkusruYYenNb84g6GgWilA2PwQxuW6CwTJ7PeAM9KkA3+HQm/hwAme+/I74940FoyOXMnA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-horizontal-line@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-46.0.3.tgz#c57556048fbb22221a347993e2ead695f05f730a"
-  integrity sha512-mct0XA6XxSk9BXorR5HA6jiDmf40Wm2HbwSEL8RcCQ4s/ak+3c85loUQZtV5Enaro8ejUkQ30nbqUnrO21Z8ZA==
+"@ckeditor/ckeditor5-horizontal-line@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.6.0.tgz#06cafbb62c212c3cd218c04458820b1eca8b91b8"
+  integrity sha512-m7LZ0wS5GHfmm1rWR1xSs5a8e/CTx79k7ahZdexLmyKmVoI8d/rahsD7oPsaFz6E+lHHhFtz+mmcOURlpI8SCQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-html-embed@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-46.0.3.tgz#8153337107ea4ebd6cf98e8a67f57bcf5814272a"
-  integrity sha512-8Cf0L1REllrVffu4BrnNiga0mQgFcQ0V/L4ARMGR3vmafTvS2cOvMyrGJy/69oCGM0NigyU1eSzkGv04o+599w==
+"@ckeditor/ckeditor5-html-embed@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.6.0.tgz#364d2e8b290ffc72ac8da1122b1a9fa32bec9cae"
+  integrity sha512-i8/7VoWcPLuJGkGbDJVQMd63SdTVERDMcah9EqbDFR6uxX+BnhUdPDKiZmcrsIJ93uq6aiK8p3uDmoiEomWp6w==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-html-support@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-46.0.3.tgz#65164419632b679de09dd8040bf1d8ba837e7a51"
-  integrity sha512-zBRJ1aBIi/UKKRhCUvK0mTDu9c43GOINKscGJ4ZRAD8WmKdlpxO+xUfCfZouDMGwd67lD9e37LI3xZc+hGCXGA==
+"@ckeditor/ckeditor5-html-support@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.6.0.tgz#73833d4cb9ed7d16bfb1ef434f932cbd20344e1d"
+  integrity sha512-bGIhD71IUYfdC87LVh3kLDlB6UuMSyBAOPpEsOr/7r8oANhHgUI10BaImZVid03e5Wn5x+S9Jc9v1T38+eRzAQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-enter" "46.0.3"
-    "@ckeditor/ckeditor5-heading" "46.0.3"
-    "@ckeditor/ckeditor5-image" "46.0.3"
-    "@ckeditor/ckeditor5-list" "46.0.3"
-    "@ckeditor/ckeditor5-remove-format" "46.0.3"
-    "@ckeditor/ckeditor5-table" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-enter" "47.6.0"
+    "@ckeditor/ckeditor5-heading" "47.6.0"
+    "@ckeditor/ckeditor5-image" "47.6.0"
+    "@ckeditor/ckeditor5-list" "47.6.0"
+    "@ckeditor/ckeditor5-remove-format" "47.6.0"
+    "@ckeditor/ckeditor5-table" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-icons@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-46.0.3.tgz#fae5dec3826f5f4a6649fa01152d1aaa234a1d30"
-  integrity sha512-ztmFx8ujcdIMTWeIQ8Hxixlexfhx8vcclV/+maDzjVHhqRNi9eZ1b/nQ7gnS4/X5Fnh6cPQuCM+3lTUR4jQscA==
+"@ckeditor/ckeditor5-icons@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.6.0.tgz#49b0a1055c73af21e9e5f23cd55cbe3c11978cc3"
+  integrity sha512-Flu9jiUG7BjVfSdIXnCx4IBshDh4G/Aw6JhnysKstA4RvAOypF7hVkuYw2tqNUdkG7YV9LbYlTlWitFvWEazkw==
 
-"@ckeditor/ckeditor5-image@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-image/-/ckeditor5-image-46.0.3.tgz#51814618fdb9ffe29217746cb28730dbf83911ab"
-  integrity sha512-9XcJVJxG+fqzwTupf7EATKeVZ+tXqeWiHLip4w/vMejjX026CPjiB3rKA2K5/H25TKDrvsMBBm22RqpK25dzCw==
+"@ckeditor/ckeditor5-image@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.6.0.tgz#f05e9dcf69df7390fe25f61c1991cc981ab3afe8"
+  integrity sha512-7X5qtCvqTSc3hJcxe6qTZ2WVIW0Q81z4l4ehIpiNF/vg4FogsSXPyJ5xro2KrNILLIXJzMx20a7BFN2S2HcepQ==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-undo" "46.0.3"
-    "@ckeditor/ckeditor5-upload" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-undo" "47.6.0"
+    "@ckeditor/ckeditor5-upload" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-indent@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-46.0.3.tgz#ee6a0279c9a09d2a8be0b43d3fb3aa48ec074417"
-  integrity sha512-XLdlp94Bitkki027adnOqL642kCSJphMoZZDYYpTNHQkKhJq6TDp8u66EFlo2/q1quVDgb1qlezDuShouYd1tQ==
+"@ckeditor/ckeditor5-indent@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.6.0.tgz#2bec60617bd36e10aede87e34f0d192f8db903d7"
+  integrity sha512-Rsnw5FHUGRlzyixRtgLeCrK2u3+d1+Bliq8hlQcMWvXB7wfD1GTDSsEU2MxGM7QtGuMbqFa+gO0hfzjEFgRv5g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-heading" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-list" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-heading" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-list" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-language@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-language/-/ckeditor5-language-46.0.3.tgz#dad8aa2fa391c247001f2812a603234992c74dfa"
-  integrity sha512-JLkDnhZxP9J/Dw7uxJtBHYrdR1q2xpkIsi+Y0fhG0cejo6Lhfnv2F/1L76EO6JxhfhrkHWrDgLwr860PYvRztA==
+"@ckeditor/ckeditor5-language@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.6.0.tgz#7f1330e37904fefb0ade9b175280c855ba5220ce"
+  integrity sha512-nwV0HvQ7xhADG74TdsYZaB3rgiJMlXEqZ1rUQ+Lcl/IcYWCeyL8UaW6CwHzwlod2wTwaZhoIgfEMAk0f50b+qg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-link@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-link/-/ckeditor5-link-46.0.3.tgz#383c13c5bfa08c36f7305abc17e6129174806cc2"
-  integrity sha512-s2wBD0QQ2Pz8wzTbh3YN83QbYRVbGp3qLwgN+8x7Y/bOuFE4AxR+JhDo14ekdXelXYxIeGJAqG2Z4SQj8v2rXQ==
+"@ckeditor/ckeditor5-link@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.6.0.tgz#3f990b045582ca90fbc68a95a11ced6baffd621b"
+  integrity sha512-YEw1y9nMqF3hYbrJ47DbeMGpyZj04uDf89tcYR5Ti27k3P4gqwCjBh/L/q+yiRmDXhfLbne7Zb4sqF6TVDBqog==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-image" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-image" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-list@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list/-/ckeditor5-list-46.0.3.tgz#342a50f272b7079a3c0bc863d70855721d4c44bc"
-  integrity sha512-KEAnyhUO6hWWa3GO6NGS7Entn2OXutCQ2+od8l5MrqeGxmpnqj0OpPX6qn+RZTVWf1RnqwErCYQhhPoQM/mlZg==
+"@ckeditor/ckeditor5-list@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.6.0.tgz#e5b68eaeca34bcfabb0891f15b7a58c6820a9176"
+  integrity sha512-LyvFrLKZS3DjNX/9J+uRJ/AvwesqD1/+BfeqGF3eP0XWhqJLI4rePosyOl3H91050zWlDuLFINo4lYGL0xDkAw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-enter" "46.0.3"
-    "@ckeditor/ckeditor5-font" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-enter" "47.6.0"
+    "@ckeditor/ckeditor5-font" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
+    es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-markdown-gfm@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-46.0.3.tgz#f3c17385d7e6489e525632bff3d59166c5e6cf94"
-  integrity sha512-ROOQsKcb03UdzyWZOD4p6vPWUpjgBRf4VXgbxKds2z19dm3fOdUwFbolpVrmYuYzdHrI/0xWM/+waD7TEOatuQ==
+"@ckeditor/ckeditor5-markdown-gfm@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.6.0.tgz#52b1be1b4fde1c6eb42f82999746abde3a751e3d"
+  integrity sha512-rgL51xVnVsXafj4OwyfjG4roZg6FXHMlcEsZsympauyehdl/IJeE9Jia8fuS7Joef7PJQNpadPr/5IE499e1Xg==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
     "@types/hast" "3.0.4"
-    ckeditor5 "46.0.3"
+    ckeditor5 "47.6.0"
     hast-util-from-dom "5.0.1"
     hast-util-to-html "9.0.5"
     hast-util-to-mdast "10.1.2"
@@ -621,271 +625,271 @@
     unified "11.0.5"
     unist-util-visit "5.0.0"
 
-"@ckeditor/ckeditor5-media-embed@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-46.0.3.tgz#5efb29e50888bae4b38a1fdb79572bad2bed930a"
-  integrity sha512-aozP4L8WQuPOHBA5qXTQnH3kQrhFJd6/J5KjKl5EicR6MUqeDkvzSLxYnltUBPByoDvkNxHD/GIL8nevgeWCrQ==
+"@ckeditor/ckeditor5-media-embed@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.6.0.tgz#4bf7b94cf0522f05108810d8c8d713e5207ddcc5"
+  integrity sha512-vKlNWEo8ICUzZXzpdo0ZA/rF6nzBglYI7EHRu1LSUAPeSA+gNoh8itXHRlox0wYQ1N5DT5f6Z6ZwxlK1pHQBQg==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-undo" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-undo" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-mention@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-46.0.3.tgz#42f2e38b6404650f2d8a09392d8069832269ccf4"
-  integrity sha512-a7sHtN8M5Glh20SbsB0KWlFxoothUwkq6cqNJKKAI6MrOYsOJX1WaMG2mUfhGr4VTrUieuJYxVtqMFuagbhBgQ==
+"@ckeditor/ckeditor5-mention@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.6.0.tgz#31f14a8089fd94ab8e4ae72064610676ab02c7b6"
+  integrity sha512-odLiEzED4fTDn5SkM+RS5Rus32ghJp6+hcSWZIHwTTQ0QRJOGab+euKyY/PqNVP0rPI2Mq+Lz5uXRO5mfarahg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-minimap@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-46.0.3.tgz#ba170968a44a87557319ea6efcf97eb3d8923e3a"
-  integrity sha512-gsac1z96MaJMFzapfzqLtEqETpI3JVXMfdQV3N0+kRbFSlUeJmrR/aHLC/+GDQAttkfOuL9i4FlWQKiDeSN15w==
+"@ckeditor/ckeditor5-minimap@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.6.0.tgz#115dade48515cf7604a90008c6b8ae104c3fb484"
+  integrity sha512-4hdS2HpkoYsx8cVsMFntN1nsvS0xsA8pHGiJFUMMNqooy77qDMRlAeaprRth+rQqruVNldGAdlnIs7LfqXoJug==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-page-break@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-46.0.3.tgz#c0fece6af88c11cddfc600e849ec04b11390c872"
-  integrity sha512-6V0O0sqgZMh47knEhhj0htWK3Oxm6jfHLWA4vi9vColwJMv9imuP72vYgrClmKHfN/QtyZ+DGmaufmhaXS2ffw==
+"@ckeditor/ckeditor5-page-break@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.6.0.tgz#b341b2263f155dbf1584db28772d2261776591f9"
+  integrity sha512-XpWPVmbCtBJD1kOtBqV/LjsVByt94xlhgk9IXXW8QE/XOoNh5Yb2JE3MisHSZ0yM3kXauROM0SWT1FVMYXx2RQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-paragraph@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-46.0.3.tgz#c6ee4808048c0c2a23450ab7438bc9dc5d140f4a"
-  integrity sha512-3OlCeyykkhcueXmo+p/LppeCvC2TtEpljLpC042EbIOCJEbSMlYEGx/AJQGetn2JV8q9L3UKfgnltpOriXAeyg==
+"@ckeditor/ckeditor5-paragraph@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.6.0.tgz#6b9f0e7a00240b6b9a7353dd64c8bee9eed93ea9"
+  integrity sha512-CxSIn9OLg/7Ol/TpwL+vZxgwwksMvR2ESI2kcSp94R8q3W8du2yoYSdPw0RzQtDuHmdGFs8JuN6xLYEU37oLBw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
 
-"@ckeditor/ckeditor5-paste-from-office@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-46.0.3.tgz#79de54d4cdec9531f254256d8e4d251aa02f6d38"
-  integrity sha512-pgqBTqP3oIFbmHvk1ddICDmyvBvFE9d+jO0busPXl5oWIqTLaaumwWaredEEUJpYmu02POSrK+WPGS0Qis6mdg==
+"@ckeditor/ckeditor5-paste-from-office@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.6.0.tgz#c3ce43517387356d787f4a777866f5fb1116cb3c"
+  integrity sha512-lS33vEq8l8MoxJe5aSC3Pem1pt+SAHI/zlf83twmBw/pb0nDjuB3HjkK+Y4Qbe5RQc/4llPJ/PN8VlR5QWyBcg==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-remove-format@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-46.0.3.tgz#9f73003093a2958f32baffda6024f07b557f28ef"
-  integrity sha512-rrGeK1NGE5o04/wuyMq10BD7bJ7qkVZq74dDXb7G6l1IkFWU/lY5SLt1K4FgVunY+oBcsena+hktwqgEsmEqdg==
+"@ckeditor/ckeditor5-remove-format@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.6.0.tgz#5b5a00f7fa9501b2e2da3bc4d7b0e7204c834efb"
+  integrity sha512-9+ygu79dgcynGYnQ5xkBOOwRS4DseF1gkSG4fsOfgR+53yGaDfmHrHAX4DBOrirpFPVYxBWkrbFPMY+2Wcvo4g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-restricted-editing@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-46.0.3.tgz#52b32ac9c9ecfcfa12266e313b62936dcb75a1bc"
-  integrity sha512-b1NUb7nEKdb0R5UOukXRXOeweOIE3Dsa64uwV/H6ZnRfdOmH37TVSKFJ2lWVvPUUljsT3SVdSZbl1aP4aA1SBA==
+"@ckeditor/ckeditor5-restricted-editing@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.6.0.tgz#95d063b835a10a0b0ce8e2f311292aed639817c1"
+  integrity sha512-vZ0ITt/ozwwUVP57GhqK7Q82yeOd3s3YgjNmNu2EFpd1apR2pYkNTJ2urghUiutVWQwBYum/H1WMwUxdOKC2tw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-select-all@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-46.0.3.tgz#a785a8cf89ddefb07e9cc9adc02844667bc02bd6"
-  integrity sha512-Uxr3/+TRLUIOGubXo/86yzqLGgoEdPV2rGqz40ulrVhG1Q7hOYerJPDs67ULPq6DLukoFFARRTah+UN9EOYRRw==
+"@ckeditor/ckeditor5-select-all@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.6.0.tgz#b14def862dba6847f237cfe4c732f799817bc6e5"
+  integrity sha512-AT6/MSUivNd3x0hYYTb8oVGtAdJ5mNJBCwM8RvjkWmX5RhqGv5xVAHt26w13mH+GNGyhot3aKVrmPgTfY7Zmqg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
 
-"@ckeditor/ckeditor5-show-blocks@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-46.0.3.tgz#a912926c7102797426040a1bc36b73dcd380fbe5"
-  integrity sha512-YSa+Q49hQe4oRxIFsnUjzIFRG1M5+2vWjzYwS84hQAR0xDMZDD0SqIS6poC3QewuIS/525bcnmASBwXZUrRdIA==
+"@ckeditor/ckeditor5-show-blocks@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.6.0.tgz#45eeee2b5bb56bc868e204c98613f992efff7560"
+  integrity sha512-jh9zSrHzjKf8Wqy6Y71+0sjkoCIiLJM13aIseaNuSuxpTU9RvSxciZp2wjpixjsWg3g0iD91QV+XPrVoEkfjgw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-source-editing@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-46.0.3.tgz#ea664512ecd36ec5a32f5ee7f7bbd48e69e279c1"
-  integrity sha512-zJMa7ekyaeQAqAysFZDRwPRyJ7+ejaP2twYvRJQARf/BgZ6YZdSDvSoW1gGIKN/c/f0XWOSTDBdRCciPZu9vCg==
+"@ckeditor/ckeditor5-source-editing@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.6.0.tgz#0e1ea17f435280b957cc442834212e26b5b1499f"
+  integrity sha512-3GD5xVrvl7ddifeF99pSPmekJhoFZmLizboBBIln6n/ZdHm4wXHCmF9ELvUSPJsxFiHASWtEVEMyHVKk6A3J8g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-theme-lark" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-theme-lark" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-special-characters@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-46.0.3.tgz#94b62a510608b47247c243fe12762fdfcdb1d4b4"
-  integrity sha512-PihS9/nmrGXaycsI3TSqVK0qGlc2ZSE3XzL7dEKTCyUta7vvI7hCC/jDaTtfch2d0fZhnIXovlgqlj35u2PjDw==
+"@ckeditor/ckeditor5-special-characters@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.6.0.tgz#25c69b01bb9a8ebdaed87cf254a3d885efb65d29"
+  integrity sha512-QVkL19eOEJshIEBjBHU9XP/DXY2P1xgts7EAC4e+XRvfL/wZLzVdCZZaIC4ELdiZD1wYUGpbL+jiV/twGQxWmg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
 
-"@ckeditor/ckeditor5-style@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-style/-/ckeditor5-style-46.0.3.tgz#d1c75502c27cfd717a93f238b702432e48a5b02b"
-  integrity sha512-/4kOCM0/s4O65AA6tHdTK9joPFaTs/Uk14RHlyGP6+QJQ5FcNx9g2yJ1HxhRAdkMLy3AsVol9lqqFXC00+W7BA==
+"@ckeditor/ckeditor5-style@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.6.0.tgz#35055e113ea3a21f59009b5dbe89cd1bef48909a"
+  integrity sha512-kr2KsSXxwWwkcox85OP8FIIjhoNDhSUURErf/B7kMf28CZcsV8wNv9a0A0gMk0FQDstmtXjUEsRgdHWIzpr/IA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-html-support" "46.0.3"
-    "@ckeditor/ckeditor5-list" "46.0.3"
-    "@ckeditor/ckeditor5-table" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-html-support" "47.6.0"
+    "@ckeditor/ckeditor5-list" "47.6.0"
+    "@ckeditor/ckeditor5-table" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-table@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-table/-/ckeditor5-table-46.0.3.tgz#39bf048644c3fcc6a9747233b54803bcd86925fe"
-  integrity sha512-Bt7d02s96cv28Xc+LxNRYBNrqlG7gI5xB8gjQWCuoIYHVikxtDUSBowu7q1UOkBmX/TEHuUpnYjUdBKD5M2n5w==
+"@ckeditor/ckeditor5-table@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.6.0.tgz#6d9bce4500e96e3e9a4bd3271661239903117864"
+  integrity sha512-JkyEJpm/WDr9U6eQ0a9wN5MUVAoqP0lk6KPnAGn64TCHAs36raeTgNEIeLbWs+1rYcl3N5IiEG+J3TNzlPpjNA==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-theme-lark@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-46.0.3.tgz#3707200acb4da4a8ba2a2afadb20a8b1bc0a9edb"
-  integrity sha512-0w4fwXFExlcsDsPXgNrQz86WJWCUwIYJkcRbjL+K3fMRYBPGVoBO25OHL7tPy2rYvrnZindCJXW9w8FzKSsKhA==
+"@ckeditor/ckeditor5-theme-lark@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.6.0.tgz#a9f2ffaf65907e0d98552e5fe15818cdd9aab9f9"
+  integrity sha512-zXZLMcTcR7dSeeybQ5qOnaAk/UicN7BzyRJEFVRKTXpKCloaMFv6YX3xneEpAdH39cY265FhfVSu/Vwvthdr0Q==
   dependencies:
-    "@ckeditor/ckeditor5-ui" "46.0.3"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
 
-"@ckeditor/ckeditor5-typing@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.3.tgz#449eb12d2916b8d6ffe026ee19a823cbeda1b460"
-  integrity sha512-iyxTTWIJ1/DpjCk+Uca9bE8P+Q7nvMssustEoMd6b3n39McCxnnonW7hrLUjFsRf/lPuvcAhpvFApoy2cbBRZA==
+"@ckeditor/ckeditor5-typing@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.6.0.tgz#c676c6e169a819e91389336effc4f0f98868b438"
+  integrity sha512-7dZylw4YGpxM4yXOO/vT9itMfJlyzkRe1+S3eC34Thh7q4pOOYERQQHuMVi4x+bifMyhR3AgpY8OdJ58R3gLqg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-ui@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz#58d03f07402245ee92a9e6caad84f8a36e7770d4"
-  integrity sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==
+"@ckeditor/ckeditor5-ui@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.6.0.tgz#c75c46a11e700097dad388f90380aa8e02e61ab5"
+  integrity sha512-bwQyS0APV01GIRzUtp7MLn8lVK60WKRCCs1FNYnpT+oPULgF4XycXwEoARzctfCdhoda3aQulVReC/tZkUeZkw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-editor-multi-root" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-editor-multi-root" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
     "@types/color-convert" "2.0.4"
     color-convert "3.1.0"
     color-parse "2.0.2"
     es-toolkit "1.39.5"
     vanilla-colorful "0.7.2"
 
-"@ckeditor/ckeditor5-undo@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-46.0.3.tgz#0aa086fb2df862451e525dd9f24bfd34410a2bfc"
-  integrity sha512-DnSBUIVOpARMDOtMrwvAOYAMZK263ubGLp48N4Yb4bpbE9VwH9KUaTNP1aRRE36wQ46KaPYiROqhnnq+RaemLQ==
+"@ckeditor/ckeditor5-undo@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.6.0.tgz#b44336204216702f328cecbe3beeb23cb9f720ff"
+  integrity sha512-sUXZCd2ZvKEKKZTzAQWaIrJfUO7E22w6+4rnx3i5H9YyUBiJF53r/O4/HJGZxshTskZe2f9nHp5pHSbFSC8UlA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
 
-"@ckeditor/ckeditor5-upload@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-46.0.3.tgz#8437e5d17db98a2c2e646f0b06e5c8941dba2b57"
-  integrity sha512-VfC3KG1fIaXQkzQRjIlt3b+G44DPj39jD9I5cepLN/xXsHU/EAUcJWXScsd/GlViSDR0DUDCygWyhIIbF/Vobw==
+"@ckeditor/ckeditor5-upload@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.6.0.tgz#d6c186f3c91c7b464e40b9a9c3306dcd48845e86"
+  integrity sha512-bCjMHRfQWImu/6bmvPbOjdb3Kl+mT52SX3XKp5kmnKPESQhdfrWqVSr8H8+QpJi+0GuSxVEE3GcawPNwK+NqEg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
 
-"@ckeditor/ckeditor5-utils@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz#58831c99d3834b17146ea2a3d06d93fab932a1e2"
-  integrity sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==
+"@ckeditor/ckeditor5-utils@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.6.0.tgz#ce8f38cdc063a15853cac311ddbcf5de87baffcc"
+  integrity sha512-+IWW2h6lGjXjLM6qlTHhB8xA7aR500KYQ7FteIn+5Aa5fT0ytyth8+AtmqpVJgXEtIK7GRCuexp1SFAcGntB/g==
   dependencies:
-    "@ckeditor/ckeditor5-ui" "46.0.3"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-watchdog@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-46.0.3.tgz#78a6430ce6b9db0c8c0fcf5d5a2a539869ed7b29"
-  integrity sha512-TcSM3n9bsJ+Rpzc7NFN2BdobxXAnRJ52n0XY8CeVYZ0VA61GtG/zINH+OdEUORcpqKylH4F1ftyNEwf6cdUbPA==
+"@ckeditor/ckeditor5-watchdog@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.6.0.tgz#0b54d2331affb4536effef93909d343817b95c83"
+  integrity sha512-0oxx4Gxy5M7V3n4Iy7z6N10MzR/fwrOkFipaiisUbeMb0vHkprI4/i3i/I76iwLGYReSzu7E2Ha6+r9k5dtlfQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-editor-multi-root" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-editor-multi-root" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-widget@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-46.0.3.tgz#4fda5f828f7a35e6d8b80b186d053b140cd1b5da"
-  integrity sha512-h5+KbQslzDVWntJQYCkSIj0huJSvE/lkjWTVCsbo2wmbKg6jusP+1oQ5ENtd7Nz4bpJlT83UkKDslSrF23xKlA==
+"@ckeditor/ckeditor5-widget@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.6.0.tgz#eaf198832e7defb83c9549786b16829dc093f300"
+  integrity sha512-/HMwSHiupKVDSEDFgqzfhGEksXN83bM/VTE00e1d4lP4CpNx6HAIopajPHu4dMDFLnIPPqFbtwdTKX9S/ffH3Q==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-enter" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-enter" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
     es-toolkit "1.39.5"
 
-"@ckeditor/ckeditor5-word-count@46.0.3":
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-46.0.3.tgz#d0ffdb77e907f2eb913dade822a3b32b06194065"
-  integrity sha512-Qobva/b/79t4hD6ZgWsBT3PgGIFXU2dZW62kFDJNVkGpq1pkKboIdq7Iu57OffLDJaV+xkAmEvV6cIDWc4KADA==
+"@ckeditor/ckeditor5-word-count@47.6.0":
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.6.0.tgz#2b367dbba743b34d26b65f92cbfa6413d8ff9388"
+  integrity sha512-XDZSCXWsbbGzG4Cimbl9ArS3mKD7IllvQGYOHZgry80iqvI+V488G7baAlNV+adgdAdeCeaI0VZjdJSrQ8brUQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    ckeditor5 "46.0.3"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    ckeditor5 "47.6.0"
     es-toolkit "1.39.5"
 
 "@esbuild/aix-ppc64@0.25.11":
@@ -1365,72 +1369,72 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
-ckeditor5@46.0.3:
-  version "46.0.3"
-  resolved "https://registry.yarnpkg.com/ckeditor5/-/ckeditor5-46.0.3.tgz#aa1f52ad6542e90aa4b720e592012c979e8b8194"
-  integrity sha512-BGadZ1td6emWnNVbX40nygpxZMAYQvtC/wRhdhedJpjqmwXQmwLte9Y9RZg+lnomrEiLiaxzFsz1j4I6u2fBnA==
+ckeditor5@47.6.0:
+  version "47.6.0"
+  resolved "https://registry.yarnpkg.com/ckeditor5/-/ckeditor5-47.6.0.tgz#f9391aaebb435bdb1b9b8ecc3e8b38ebbdee94a4"
+  integrity sha512-OynbpuohqK5XV+d5itPRMnXrFjbrTcJQp8xwFbeZzvD58aeoxVSLnM8hX2V6o3wM6OvkBdSGuKq+XhjKcRfM9g==
   dependencies:
-    "@ckeditor/ckeditor5-adapter-ckfinder" "46.0.3"
-    "@ckeditor/ckeditor5-alignment" "46.0.3"
-    "@ckeditor/ckeditor5-autoformat" "46.0.3"
-    "@ckeditor/ckeditor5-autosave" "46.0.3"
-    "@ckeditor/ckeditor5-basic-styles" "46.0.3"
-    "@ckeditor/ckeditor5-block-quote" "46.0.3"
-    "@ckeditor/ckeditor5-bookmark" "46.0.3"
-    "@ckeditor/ckeditor5-ckbox" "46.0.3"
-    "@ckeditor/ckeditor5-ckfinder" "46.0.3"
-    "@ckeditor/ckeditor5-clipboard" "46.0.3"
-    "@ckeditor/ckeditor5-cloud-services" "46.0.3"
-    "@ckeditor/ckeditor5-code-block" "46.0.3"
-    "@ckeditor/ckeditor5-core" "46.0.3"
-    "@ckeditor/ckeditor5-easy-image" "46.0.3"
-    "@ckeditor/ckeditor5-editor-balloon" "46.0.3"
-    "@ckeditor/ckeditor5-editor-classic" "46.0.3"
-    "@ckeditor/ckeditor5-editor-decoupled" "46.0.3"
-    "@ckeditor/ckeditor5-editor-inline" "46.0.3"
-    "@ckeditor/ckeditor5-editor-multi-root" "46.0.3"
-    "@ckeditor/ckeditor5-emoji" "46.0.3"
-    "@ckeditor/ckeditor5-engine" "46.0.3"
-    "@ckeditor/ckeditor5-enter" "46.0.3"
-    "@ckeditor/ckeditor5-essentials" "46.0.3"
-    "@ckeditor/ckeditor5-find-and-replace" "46.0.3"
-    "@ckeditor/ckeditor5-font" "46.0.3"
-    "@ckeditor/ckeditor5-fullscreen" "46.0.3"
-    "@ckeditor/ckeditor5-heading" "46.0.3"
-    "@ckeditor/ckeditor5-highlight" "46.0.3"
-    "@ckeditor/ckeditor5-horizontal-line" "46.0.3"
-    "@ckeditor/ckeditor5-html-embed" "46.0.3"
-    "@ckeditor/ckeditor5-html-support" "46.0.3"
-    "@ckeditor/ckeditor5-icons" "46.0.3"
-    "@ckeditor/ckeditor5-image" "46.0.3"
-    "@ckeditor/ckeditor5-indent" "46.0.3"
-    "@ckeditor/ckeditor5-language" "46.0.3"
-    "@ckeditor/ckeditor5-link" "46.0.3"
-    "@ckeditor/ckeditor5-list" "46.0.3"
-    "@ckeditor/ckeditor5-markdown-gfm" "46.0.3"
-    "@ckeditor/ckeditor5-media-embed" "46.0.3"
-    "@ckeditor/ckeditor5-mention" "46.0.3"
-    "@ckeditor/ckeditor5-minimap" "46.0.3"
-    "@ckeditor/ckeditor5-page-break" "46.0.3"
-    "@ckeditor/ckeditor5-paragraph" "46.0.3"
-    "@ckeditor/ckeditor5-paste-from-office" "46.0.3"
-    "@ckeditor/ckeditor5-remove-format" "46.0.3"
-    "@ckeditor/ckeditor5-restricted-editing" "46.0.3"
-    "@ckeditor/ckeditor5-select-all" "46.0.3"
-    "@ckeditor/ckeditor5-show-blocks" "46.0.3"
-    "@ckeditor/ckeditor5-source-editing" "46.0.3"
-    "@ckeditor/ckeditor5-special-characters" "46.0.3"
-    "@ckeditor/ckeditor5-style" "46.0.3"
-    "@ckeditor/ckeditor5-table" "46.0.3"
-    "@ckeditor/ckeditor5-theme-lark" "46.0.3"
-    "@ckeditor/ckeditor5-typing" "46.0.3"
-    "@ckeditor/ckeditor5-ui" "46.0.3"
-    "@ckeditor/ckeditor5-undo" "46.0.3"
-    "@ckeditor/ckeditor5-upload" "46.0.3"
-    "@ckeditor/ckeditor5-utils" "46.0.3"
-    "@ckeditor/ckeditor5-watchdog" "46.0.3"
-    "@ckeditor/ckeditor5-widget" "46.0.3"
-    "@ckeditor/ckeditor5-word-count" "46.0.3"
+    "@ckeditor/ckeditor5-adapter-ckfinder" "47.6.0"
+    "@ckeditor/ckeditor5-alignment" "47.6.0"
+    "@ckeditor/ckeditor5-autoformat" "47.6.0"
+    "@ckeditor/ckeditor5-autosave" "47.6.0"
+    "@ckeditor/ckeditor5-basic-styles" "47.6.0"
+    "@ckeditor/ckeditor5-block-quote" "47.6.0"
+    "@ckeditor/ckeditor5-bookmark" "47.6.0"
+    "@ckeditor/ckeditor5-ckbox" "47.6.0"
+    "@ckeditor/ckeditor5-ckfinder" "47.6.0"
+    "@ckeditor/ckeditor5-clipboard" "47.6.0"
+    "@ckeditor/ckeditor5-cloud-services" "47.6.0"
+    "@ckeditor/ckeditor5-code-block" "47.6.0"
+    "@ckeditor/ckeditor5-core" "47.6.0"
+    "@ckeditor/ckeditor5-easy-image" "47.6.0"
+    "@ckeditor/ckeditor5-editor-balloon" "47.6.0"
+    "@ckeditor/ckeditor5-editor-classic" "47.6.0"
+    "@ckeditor/ckeditor5-editor-decoupled" "47.6.0"
+    "@ckeditor/ckeditor5-editor-inline" "47.6.0"
+    "@ckeditor/ckeditor5-editor-multi-root" "47.6.0"
+    "@ckeditor/ckeditor5-emoji" "47.6.0"
+    "@ckeditor/ckeditor5-engine" "47.6.0"
+    "@ckeditor/ckeditor5-enter" "47.6.0"
+    "@ckeditor/ckeditor5-essentials" "47.6.0"
+    "@ckeditor/ckeditor5-find-and-replace" "47.6.0"
+    "@ckeditor/ckeditor5-font" "47.6.0"
+    "@ckeditor/ckeditor5-fullscreen" "47.6.0"
+    "@ckeditor/ckeditor5-heading" "47.6.0"
+    "@ckeditor/ckeditor5-highlight" "47.6.0"
+    "@ckeditor/ckeditor5-horizontal-line" "47.6.0"
+    "@ckeditor/ckeditor5-html-embed" "47.6.0"
+    "@ckeditor/ckeditor5-html-support" "47.6.0"
+    "@ckeditor/ckeditor5-icons" "47.6.0"
+    "@ckeditor/ckeditor5-image" "47.6.0"
+    "@ckeditor/ckeditor5-indent" "47.6.0"
+    "@ckeditor/ckeditor5-language" "47.6.0"
+    "@ckeditor/ckeditor5-link" "47.6.0"
+    "@ckeditor/ckeditor5-list" "47.6.0"
+    "@ckeditor/ckeditor5-markdown-gfm" "47.6.0"
+    "@ckeditor/ckeditor5-media-embed" "47.6.0"
+    "@ckeditor/ckeditor5-mention" "47.6.0"
+    "@ckeditor/ckeditor5-minimap" "47.6.0"
+    "@ckeditor/ckeditor5-page-break" "47.6.0"
+    "@ckeditor/ckeditor5-paragraph" "47.6.0"
+    "@ckeditor/ckeditor5-paste-from-office" "47.6.0"
+    "@ckeditor/ckeditor5-remove-format" "47.6.0"
+    "@ckeditor/ckeditor5-restricted-editing" "47.6.0"
+    "@ckeditor/ckeditor5-select-all" "47.6.0"
+    "@ckeditor/ckeditor5-show-blocks" "47.6.0"
+    "@ckeditor/ckeditor5-source-editing" "47.6.0"
+    "@ckeditor/ckeditor5-special-characters" "47.6.0"
+    "@ckeditor/ckeditor5-style" "47.6.0"
+    "@ckeditor/ckeditor5-table" "47.6.0"
+    "@ckeditor/ckeditor5-theme-lark" "47.6.0"
+    "@ckeditor/ckeditor5-typing" "47.6.0"
+    "@ckeditor/ckeditor5-ui" "47.6.0"
+    "@ckeditor/ckeditor5-undo" "47.6.0"
+    "@ckeditor/ckeditor5-upload" "47.6.0"
+    "@ckeditor/ckeditor5-utils" "47.6.0"
+    "@ckeditor/ckeditor5-watchdog" "47.6.0"
+    "@ckeditor/ckeditor5-widget" "47.6.0"
+    "@ckeditor/ckeditor5-word-count" "47.6.0"
 
 clone-regexp@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
This pull request includes a version bump for TrustyCms and updates the `ckeditor5` dependency to a newer version. These changes help keep the application up-to-date and compatible with the latest features and security fixes.

Version and dependency updates:

* Updated `lib/trusty_cms/version.rb` to set the `VERSION` constant to `'7.0.49'`.
* Updated `package.json` to use `ckeditor5` version `^47.6.0` instead of `46.0.3`.