### PR TITLE
Use clipped config for asset config, allow a video size vs asset size

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -51,6 +51,7 @@ class Admin::AssetsController < Admin::ResourceController
     @page_attachments = []
     uploads = Array(asset_params.dig('asset', 'asset')).reject(&:blank?)
 
+
     uploads.each do |uploaded_asset|
       result = process_uploaded_asset(uploaded_asset)
 
@@ -63,13 +64,15 @@ class Admin::AssetsController < Admin::ResourceController
         @assets << @asset
       else
         flash[result.fetch(:flash_type, :error)] = result[:error]
+        @error = result[:error]
       end
     end
 
     if asset_params[:for_attachment]
       render partial: 'admin/page_attachments/attachment', collection: @page_attachments
-    else
-      response_for :create
+    elsif @error.present?
+      flash[:error] = @error
+      redirect_to new_admin_asset_path
     end
   end
 

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -115,7 +115,7 @@ class Admin::AssetsController < Admin::ResourceController
   end
 
   def failure_response(message, status, flash_type)
-    @errors = { error: message, status: status, flash_type: flash_type }
+    { error: message, status: status, flash_type: flash_type }
   end
 
   def compress(uploaded_asset)

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -1,7 +1,6 @@
 class Admin::AssetsController < Admin::ResourceController
   paginate_models(per_page: 50)
   COMPRESS_FILE_TYPE = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'].freeze
-  APPROVED_CONTENT_TYPES = Asset::APPROVED_CONTENT_TYPES
 
   def index
     assets = Asset.order('created_at DESC')
@@ -83,7 +82,7 @@ class Admin::AssetsController < Admin::ResourceController
       return failure_response('Please only upload assets that have a valid extension in the name.', :unprocessable_entity, :notice)
     end
 
-    unless APPROVED_CONTENT_TYPES.include?(uploaded_asset.content_type)
+    unless Asset.approved_content_types.include?(uploaded_asset.content_type)
       return failure_response('Unsupported file type.', :unsupported_media_type, :error)
     end
 

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -64,15 +64,17 @@ class Admin::AssetsController < Admin::ResourceController
         @assets << @asset
       else
         flash[result.fetch(:flash_type, :error)] = result[:error]
-        @error = result[:error]
+        @errors = result[:error]
       end
     end
 
     if asset_params[:for_attachment]
       render partial: 'admin/page_attachments/attachment', collection: @page_attachments
-    elsif @error.present?
-      flash[:error] = @error
+    elsif @errors.present?
+      flash[:error] = @errors
       redirect_to new_admin_asset_path
+    else
+      response_for :create
     end
   end
 
@@ -113,7 +115,7 @@ class Admin::AssetsController < Admin::ResourceController
   end
 
   def failure_response(message, status, flash_type)
-    { error: message, status: status, flash_type: flash_type }
+    @errors = { error: message, status: status, flash_type: flash_type }
   end
 
   def compress(uploaded_asset)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,8 +1,6 @@
 require 'trusty_cms/geometry'
 
 class Asset < ActiveRecord::Base
-  APPROVED_CONTENT_TYPES = %w[application/zip image/jpg image/jpeg image/png image/gif application/pdf text/css text/calendar].freeze
-
   has_many :page_attachments, dependent: :destroy
   has_many :pages, through: :page_attachments
   has_site if respond_to? :has_site
@@ -37,14 +35,14 @@ class Asset < ActiveRecord::Base
     end
   }
 
+  def self.approved_content_types
+    AssetType.known_mimetypes
+  end
+
   has_one_attached :asset
-  validates :asset,
-            presence: true,
-            blob:
-              {
-                content_type: APPROVED_CONTENT_TYPES,
-                size_range: 1..10.megabytes,
-              }
+  validates :asset, presence: true
+  validates :asset, blob: { size_range: 1..10.megabytes }, if: -> { asset.attached? }
+  validate :approved_content_type, if: -> { asset.attached? }
   before_validation :sync_attachment_metadata
   before_save :assign_title
   before_save :assign_uuid
@@ -233,6 +231,12 @@ class Asset < ActiveRecord::Base
     else
       { resize_to_limit: [width, height].compact }
     end
+  end
+
+  def approved_content_type
+    return if Asset.approved_content_types.include?(asset.content_type)
+
+    errors.add(:asset, :content_type, filename: asset.filename.to_s)
   end
 
   def sync_attachment_metadata

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -48,7 +48,6 @@ class Asset < ActiveRecord::Base
   before_save :assign_uuid
 
   def asset_within_configured_size
-    binding.pry
     limit_mb =
       if video_content_type?
         TrustyCms.config['assets.max_video_size'].to_i

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -41,7 +41,8 @@ class Asset < ActiveRecord::Base
 
   has_one_attached :asset
   validates :asset, presence: true
-  validates :asset, blob: { size_range: 1..10.megabytes }, if: -> { asset.attached? }
+  validates :asset, blob: { size_range: 1..TrustyCms.config['assets.max_asset_size'].to_i.megabytes }, if: -> { asset.attached? && !video_content_type? }
+  validates :asset, blob: { size_range: 1..TrustyCms.config['assets.max_video_size'].to_i.megabytes }, if: -> { asset.attached? && video_content_type? }
   validate :approved_content_type, if: -> { asset.attached? }
   before_validation :sync_attachment_metadata
   before_save :assign_title
@@ -231,6 +232,10 @@ class Asset < ActiveRecord::Base
     else
       { resize_to_limit: [width, height].compact }
     end
+  end
+
+  def video_content_type?
+    AssetType.known?(:video) && AssetType.find(:video).mime_types.include?(content_type)
   end
 
   def approved_content_type

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -41,12 +41,26 @@ class Asset < ActiveRecord::Base
 
   has_one_attached :asset
   validates :asset, presence: true
-  validates :asset, blob: { size_range: 1..TrustyCms.config['assets.max_asset_size'].to_i.megabytes }, if: -> { asset.attached? && !video_content_type? }
-  validates :asset, blob: { size_range: 1..TrustyCms.config['assets.max_video_size'].to_i.megabytes }, if: -> { asset.attached? && video_content_type? }
+  validate :asset_within_configured_size, if: -> { asset.attached? }
   validate :approved_content_type, if: -> { asset.attached? }
   before_validation :sync_attachment_metadata
   before_save :assign_title
   before_save :assign_uuid
+
+  def asset_within_configured_size
+    binding.pry
+    limit_mb =
+      if video_content_type?
+        TrustyCms.config['assets.max_video_size'].to_i
+      else
+        TrustyCms.config['assets.max_asset_size'].to_i
+      end
+
+    limit_bytes = limit_mb.megabytes
+    return if asset.blob.byte_size.between?(1, limit_bytes)
+
+    errors.add(:asset, :wrong_size_error, limit_mb: limit_mb)
+  end
 
   def asset_type
     AssetType.for(asset)

--- a/app/views/admin/configuration/_clipped_edit.html.haml
+++ b/app/views/admin/configuration/_clipped_edit.html.haml
@@ -2,6 +2,7 @@
   %h3
     = t('clipped_extension.assets')
   %p= edit_config 'assets.max_asset_size'
+  %p= edit_config 'assets.max_video_size'
   %p= edit_config 'assets.display_size'
   %p= edit_config 'assets.insertion_size'
   - %w{image video pdf}.each do |type|

--- a/app/views/admin/configuration/_clipped_show.html.haml
+++ b/app/views/admin/configuration/_clipped_show.html.haml
@@ -3,6 +3,8 @@
 %p.ruled
   = show_config 'assets.max_asset_size'
 %p.ruled
+  = show_config 'assets.max_video_size'
+%p.ruled
   = show_config 'assets.display_size'
 %p.ruled
   = show_config 'assets.insertion_size'

--- a/config/initializers/trusty_cms_config.rb
+++ b/config/initializers/trusty_cms_config.rb
@@ -29,7 +29,8 @@ Rails.application.reloader.to_prepare do
         thumbs.define 'pdf', default: 'normal:size=640x640>,format=jpg|small:size=320x320>,format=jpg'
       end
 
-      assets.define 'max_asset_size', default: 5, type: :integer, units: 'MB'
+      assets.define 'max_asset_size', default: 10, type: :integer, units: 'MB'
+      assets.define 'max_video_size', default: 50, type: :integer, units: 'MB'
       assets.define 'display_size', default: 'normal', allow_blank: true
       assets.define 'insertion_size', default: 'normal', allow_blank: true
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,8 +18,8 @@ en:
             asset:
               blank: 'You must choose a file to upload!'
               content_type: '%{filename} is not a supported file type.'
-              max_size_error: '%{filename} is too large (maximum is %{max_size}).'
-              min_size_error: '%{filename} must be larger than %{min_size}.'
+              max_size_error: 'File is too large (maximum is %{max_size}).'
+              min_size_error: 'File is too small (minimum is %{min_size}).'
         page:
           attributes:
             slug:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
               content_type: '%{filename} is not a supported file type.'
               max_size_error: 'File is too large (maximum is %{max_size}).'
               min_size_error: 'File is too small (minimum is %{min_size}).'
+              wrong_size_error: 'File size must be between 1 byte and %{limit_mb} MB'
         page:
           attributes:
             slug:
@@ -137,6 +138,7 @@ en:
       display_size: 'Display Size'
       insertion_size: 'Insertion Size'
       max_asset_size: 'Max Asset Size'
+      max_video_size: 'Max Video Size'
       path: 'Path'
       s3:
         bucket: 'Bucket'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,9 @@ en:
           attributes:
             asset:
               blank: 'You must choose a file to upload!'
+              content_type: '%{filename} is not a supported file type.'
+              max_size_error: '%{filename} is too large (maximum is %{max_size}).'
+              min_size_error: '%{filename} must be larger than %{min_size}.'
         page:
           attributes:
             slug:

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Asset, type: :model do
 
   describe 'validations' do
     before do
-      expect(AssetType.known_mimetypes).to include('image/png', 'video/mp4', 'text/plain')
+      AssetType.new :image, icon: 'image', styles: :standard, extensions: %w[jpg jpeg png gif], mime_types: %w[image/png image/x-png image/jpeg image/pjpeg image/jpg image/gif] unless AssetType.known?(:image)
+      AssetType.new :video, icon: 'video', mime_types: %w[video/mp4 video/mpeg video/quicktime video/webm] unless AssetType.known?(:video)
+      AssetType.new :document, icon: 'document', mime_types: %w[application/msword application/rtf text/plain text/html] unless AssetType.known?(:document)
     end
 
     it 'is valid when the content type is approved' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -30,67 +30,65 @@ RSpec.describe Asset, type: :model do
       expect(asset.errors[:asset]).to include(a_string_matching(/file type/i))
     end
 
-    it 'is invalid when a non-video file exceeds the maximum asset size' do
-      max_size = TrustyCms.config['assets.max_asset_size'].to_i
-
-      Tempfile.open(['large', '.png']) do |tempfile|
-        tempfile.binmode
-        tempfile.write('0' * (max_size.megabytes + 1))
-        tempfile.rewind
-
-        uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'image/png')
-        asset = described_class.new(asset: uploaded)
-
-        expect(asset).not_to be_valid
-        expect(asset.errors[:asset]).to include(a_string_matching(/#{max_size} MB/))
+    context 'with stubbed size limits (1 MB asset / 2 MB video)' do
+      before do
+        allow(TrustyCms.config).to receive(:[]).and_call_original
+        allow(TrustyCms.config).to receive(:[]).with('assets.max_asset_size').and_return('1')
+        allow(TrustyCms.config).to receive(:[]).with('assets.max_video_size').and_return('2')
       end
-    end
 
-    it 'is invalid when a video file exceeds the maximum video size' do
-      max_size = TrustyCms.config['assets.max_video_size'].to_i
+      it 'is invalid when a non-video file exceeds the maximum asset size' do
+        Tempfile.open(['large', '.png']) do |tempfile|
+          tempfile.binmode
+          tempfile.write('0' * (1.megabyte + 1))
+          tempfile.rewind
 
-      Tempfile.open(['large', '.mp4']) do |tempfile|
-        tempfile.binmode
-        tempfile.write('0' * (max_size.megabytes + 1))
-        tempfile.rewind
+          uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'image/png')
+          asset = described_class.new(asset: uploaded)
 
-        uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'video/mp4')
-        asset = described_class.new(asset: uploaded)
-
-        expect(asset).not_to be_valid
-        expect(asset.errors[:asset]).to include(a_string_matching(/#{max_size} MB/))
+          expect(asset).not_to be_valid
+          expect(asset.errors[:asset]).to include(a_string_matching(/1 MB/))
+        end
       end
-    end
 
-    it 'allows a video file that exceeds the asset size limit but is within the video size limit' do
-      asset_limit = TrustyCms.config['assets.max_asset_size'].to_i
-      video_limit = TrustyCms.config['assets.max_video_size'].to_i
-      size = asset_limit.megabytes + 1.megabyte
+      it 'is invalid when a video file exceeds the maximum video size' do
+        Tempfile.open(['large', '.mp4']) do |tempfile|
+          tempfile.binmode
+          tempfile.write('0' * (2.megabytes + 1))
+          tempfile.rewind
 
-      skip 'video limit must be larger than asset limit for this test to be meaningful' unless video_limit > asset_limit
+          uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'video/mp4')
+          asset = described_class.new(asset: uploaded)
 
-      Tempfile.open(['video', '.mp4']) do |tempfile|
-        tempfile.binmode
-        tempfile.write('0' * size)
-        tempfile.rewind
-
-        uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'video/mp4')
-        asset = described_class.new(asset: uploaded)
-
-        expect(asset).to be_valid
+          expect(asset).not_to be_valid
+          expect(asset.errors[:asset]).to include(a_string_matching(/2 MB/))
+        end
       end
-    end
 
-    it 'allows a video file within the maximum video size' do
-      Tempfile.open(['video', '.mp4']) do |tempfile|
-        tempfile.binmode
-        tempfile.write('0' * 1.megabyte)
-        tempfile.rewind
+      it 'allows a video file that exceeds the asset size limit but is within the video size limit' do
+        Tempfile.open(['video', '.mp4']) do |tempfile|
+          tempfile.binmode
+          tempfile.write('0' * (1.megabyte + 1.kilobyte))
+          tempfile.rewind
 
-        uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'video/mp4')
-        asset = described_class.new(asset: uploaded)
+          uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'video/mp4')
+          asset = described_class.new(asset: uploaded)
 
-        expect(asset).to be_valid
+          expect(asset).to be_valid
+        end
+      end
+
+      it 'allows a video file within the maximum video size' do
+        Tempfile.open(['video', '.mp4']) do |tempfile|
+          tempfile.binmode
+          tempfile.write('0' * 1.kilobyte)
+          tempfile.rewind
+
+          uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'video/mp4')
+          asset = described_class.new(asset: uploaded)
+
+          expect(asset).to be_valid
+        end
       end
     end
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Asset, type: :model do
       asset = described_class.new(asset: upload_fixture('sample.txt', 'application/x-unsupported'))
 
       expect(asset).not_to be_valid
-      expect(asset.errors[:asset]).to include(a_string_matching(/file format/i))
+      expect(asset.errors[:asset]).to include(a_string_matching(/file type/i))
     end
 
     it 'is invalid when a non-video file exceeds the maximum asset size' do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -11,30 +11,86 @@ RSpec.describe Asset, type: :model do
   end
 
   describe 'validations' do
+    before do
+      AssetType.new :image, icon: 'image', styles: :standard, extensions: %w[jpg jpeg png gif], mime_types: %w[image/png image/x-png image/jpeg image/pjpeg image/jpg image/gif] unless AssetType.known?(:image)
+      AssetType.new :video, icon: 'video', mime_types: %w[video/mp4 video/mpeg video/quicktime video/webm] unless AssetType.known?(:video)
+      AssetType.new :document, icon: 'document', mime_types: %w[application/msword application/rtf text/plain text/html] unless AssetType.known?(:document)
+    end
+
     it 'is valid when the content type is approved' do
-      asset = described_class.new(asset: upload_fixture('sample.ics', 'text/calendar'))
+      asset = described_class.new(asset: upload_fixture('sample.txt', 'text/plain'))
 
       expect(asset).to be_valid
     end
 
     it 'is invalid when the content type is not approved' do
-      asset = described_class.new(asset: upload_fixture('sample.txt', 'text/plain'))
+      asset = described_class.new(asset: upload_fixture('sample.txt', 'application/x-unsupported'))
 
       expect(asset).not_to be_valid
       expect(asset.errors[:asset]).to include(a_string_matching(/file format/i))
     end
 
-    it 'is invalid when the file exceeds the maximum size' do
+    it 'is invalid when a non-video file exceeds the maximum asset size' do
+      max_size = TrustyCms.config['assets.max_asset_size'].to_i
+
       Tempfile.open(['large', '.png']) do |tempfile|
         tempfile.binmode
-        tempfile.write('0' * (10.megabytes + 1))
+        tempfile.write('0' * (max_size.megabytes + 1))
         tempfile.rewind
 
         uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'image/png')
         asset = described_class.new(asset: uploaded)
 
         expect(asset).not_to be_valid
-        expect(asset.errors[:asset]).to include(a_string_matching(/10 MB/))
+        expect(asset.errors[:asset]).to include(a_string_matching(/#{max_size} MB/))
+      end
+    end
+
+    it 'is invalid when a video file exceeds the maximum video size' do
+      max_size = TrustyCms.config['assets.max_video_size'].to_i
+
+      Tempfile.open(['large', '.mp4']) do |tempfile|
+        tempfile.binmode
+        tempfile.write('0' * (max_size.megabytes + 1))
+        tempfile.rewind
+
+        uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'video/mp4')
+        asset = described_class.new(asset: uploaded)
+
+        expect(asset).not_to be_valid
+        expect(asset.errors[:asset]).to include(a_string_matching(/#{max_size} MB/))
+      end
+    end
+
+    it 'allows a video file that exceeds the asset size limit but is within the video size limit' do
+      asset_limit = TrustyCms.config['assets.max_asset_size'].to_i
+      video_limit = TrustyCms.config['assets.max_video_size'].to_i
+      size = asset_limit.megabytes + 1.megabyte
+
+      skip 'video limit must be larger than asset limit for this test to be meaningful' unless video_limit > asset_limit
+
+      Tempfile.open(['video', '.mp4']) do |tempfile|
+        tempfile.binmode
+        tempfile.write('0' * size)
+        tempfile.rewind
+
+        uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'video/mp4')
+        asset = described_class.new(asset: uploaded)
+
+        expect(asset).to be_valid
+      end
+    end
+
+    it 'allows a video file within the maximum video size' do
+      Tempfile.open(['video', '.mp4']) do |tempfile|
+        tempfile.binmode
+        tempfile.write('0' * 1.megabyte)
+        tempfile.rewind
+
+        uploaded = Rack::Test::UploadedFile.new(tempfile.path, 'video/mp4')
+        asset = described_class.new(asset: uploaded)
+
+        expect(asset).to be_valid
       end
     end
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe Asset, type: :model do
 
   describe 'validations' do
     before do
-      AssetType.new :image, icon: 'image', styles: :standard, extensions: %w[jpg jpeg png gif], mime_types: %w[image/png image/x-png image/jpeg image/pjpeg image/jpg image/gif] unless AssetType.known?(:image)
-      AssetType.new :video, icon: 'video', mime_types: %w[video/mp4 video/mpeg video/quicktime video/webm] unless AssetType.known?(:video)
-      AssetType.new :document, icon: 'document', mime_types: %w[application/msword application/rtf text/plain text/html] unless AssetType.known?(:document)
+      expect(AssetType.known_mimetypes).to include('image/png', 'video/mp4', 'text/plain')
     end
 
     it 'is valid when the content type is approved' do

--- a/vendor/extensions/clipped-extension/clipped_extension.rb
+++ b/vendor/extensions/clipped-extension/clipped_extension.rb
@@ -9,11 +9,10 @@ class ClippedExtension < TrustyCms::Extension
         TrustyCms::AdminUI.send :include, ClippedAdminUI unless defined? admin.asset # defines shards for extension of the asset-admin interface
         Admin::PagesController.send :helper, Admin::AssetsHelper # currently only provides a description of asset sizes
         Page.send :include, AssetTags # radius tags for selecting sets of assets and presenting each one
-        AssetType.new :image, :icon => 'image', :default_radius_tag => 'image', :styles => :standard, :extensions => %w[jpg jpeg png gif], :mime_types => %w[image/png image/x-png image/jpeg image/pjpeg image/jpg image/gif]
-        AssetType.new :video, :icon => 'video', :styles => :standard, :mime_types => %w[application/x-mp4 video/mpeg video/quicktime video/x-la-asf video/x-ms-asf video/x-msvideo video/x-sgi-movie video/x-flv flv-application/octet-stream video/3gpp video/3gpp2 video/3gpp-tt video/BMPEG video/BT656 video/CelB video/DV video/H261 video/H263 video/H263-1998 video/H263-2000 video/H264 video/JPEG video/MJ2 video/MP1S video/MP2P video/MP2T video/mp4 video/MP4V-ES video/MPV video/mpeg4 video/mpeg4-generic video/nv video/parityfec video/pointer video/raw video/rtx video/ogg video/webm]
-        AssetType.new :audio, :icon => 'audio', :mime_types => %w[audio/mpeg audio/mpg audio/ogg application/ogg audio/x-ms-wma audio/vnd.rn-realaudio audio/x-wav]
+        AssetType.new :image, :icon => 'image', :default_radius_tag => 'image', :styles => :standard, :extensions => %w[jpg jpeg png gif webp avif], :mime_types => %w[image/png image/x-png image/jpeg image/pjpeg image/jpg image/gif image/webp image/avif]
+        AssetType.new :video, :icon => 'video', :styles => :standard, :mime_types => %w[video/mp4 video/webm video/quicktime video/mpeg video/ogg video/mp2t application/x-mp4]
+        AssetType.new :audio, :icon => 'audio', :mime_types => %w[audio/mpeg audio/mpg audio/ogg audio/mp4 audio/wav audio/x-wav application/ogg audio/flac]
         AssetType.new :pdf, :icon => 'pdf', :extensions => %w{pdf}, :mime_types => %w[application/pdf application/x-pdf], :styles => :standard
-        AssetType.new :document, :icon => 'document', :mime_types => %w[application/msword application/rtf application/vnd.ms-excel application/vnd.ms-powerpoint application/vnd.ms-project application/vnd.ms-works text/plain text/html]
         AssetType.new :other, :icon => 'unknown'
 
         admin.asset ||= TrustyCms::AdminUI.load_default_asset_regions # loads the shards defined in AssetsAdminUI

--- a/vendor/extensions/clipped-extension/lib/generators/templates/clipped_config.rb
+++ b/vendor/extensions/clipped-extension/lib/generators/templates/clipped_config.rb
@@ -3,7 +3,8 @@ TrustyCms.config do |config|
   # Uncomment and change the settings below to customize the Clipped extension
 
   # The default settings
-  # config["assets.max_asset_size"] = 5 # megabytes
+  # config["assets.max_asset_size"] = 10 # megabytes
+  # config["assets.max_video_size"] = 50 # megabytes
   # config["assets.display_size"] = "normal"
   # config["assets.insertion_size"] = "normal"
   # config["assets.create_image_thumbnails?"] = true


### PR DESCRIPTION
This pull request refactors and improves asset upload validation in the application, especially around file type and file size checks. It replaces the previous static list of approved content types with a more flexible system based on `AssetType`, introduces separate file size limits for videos and other assets, and enhances error handling and messaging. The changes also update tests to cover new validation logic.

**Validation and configuration improvements:**

* Replaces the static `APPROVED_CONTENT_TYPES` constant in `Asset` with a dynamic method that pulls approved MIME types from `AssetType`, making it easier to manage supported file types. (`app/models/asset.rb`, `app/controllers/admin/assets_controller.rb`, [[1]](diffhunk://#diff-0545770a3fbf7606692cd849fe6ca5dd4b454b9a203b8588657abbe7f0ea30b8L4-L5) [[2]](diffhunk://#diff-52d98c35c625099704543c387ac70e728efb04bfa7125d73bd81109907ae451fL4) [[3]](diffhunk://#diff-52d98c35c625099704543c387ac70e728efb04bfa7125d73bd81109907ae451fL86-R88)
* Adds separate maximum file size settings for general assets and for videos, configurable via `TrustyCms.config`, and updates validation logic accordingly. (`app/models/asset.rb`, `config/initializers/trusty_cms_config.rb`, [[1]](diffhunk://#diff-0545770a3fbf7606692cd849fe6ca5dd4b454b9a203b8588657abbe7f0ea30b8R38-R46) [[2]](diffhunk://#diff-c6779c1298604280a21c36ff135b0ba491f24a3418d444db1a724cc67ff59785L32-R33)
* Implements a custom validation method `approved_content_type` to ensure only files with approved MIME types are accepted. (`app/models/asset.rb`, [app/models/asset.rbR237-R246](diffhunk://#diff-0545770a3fbf7606692cd849fe6ca5dd4b454b9a203b8588657abbe7f0ea30b8R237-R246))

**Error handling and user feedback:**

* Improves error handling in the asset upload controller, ensuring that users are redirected with appropriate error messages when uploads fail due to validation errors. (`app/controllers/admin/assets_controller.rb`, [app/controllers/admin/assets_controller.rbR67-R75](diffhunk://#diff-52d98c35c625099704543c387ac70e728efb04bfa7125d73bd81109907ae451fR67-R75))
* Updates localization strings to provide clearer feedback for unsupported file types and file size errors. (`config/locales/en.yml`, [config/locales/en.ymlR20-R22](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R20-R22))

**Testing:**

* Expands model tests to cover the new validation logic, including checks for approved content types, maximum asset size, and maximum video size, as well as correct handling of edge cases. (`spec/models/asset_spec.rb`, [spec/models/asset_spec.rbR14-R93](diffhunk://#diff-b87e7a968ce874cb0f75453b3a3ddad13a7341ba4a70bd8356f9782150584fe0R14-R93))