### PR TITLE
Upgrade Github Actions to use Trusted Publisher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: cimg/ruby:3.3.1-node
+      - image: cimg/ruby:3.3.4-node
         environment:
           - RAILS_ENV: test
       - image: cimg/mysql:5.7.36

--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3.1'
+          ruby-version: '3.3.4'
 
       - name: Setup Brakeman
         env:

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -26,7 +26,7 @@ jobs:
           bundler-cache: true
 
       - name: Configure RubyGems credentials
-        uses: rubygems/configure-rubygems-credentials@main
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
 
       - name: Build gem
         run: |

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -9,27 +9,36 @@ jobs:
   build:
     name: Build + Publish
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
-      packages: write
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Ruby 3.0.5
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby 3.3.4
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0.5'
+          ruby-version: '3.3.4'
+          bundler-cache: true
 
-      - name: Publish to RubyGems
+      - name: Configure RubyGems credentials
+        uses: rubygems/configure-rubygems-credentials@main
+
+      - name: Build gem
         run: |
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem build *.gemspec
-          gem push *.gem
-        env:
-          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+          echo "GEM_FILE=$(ruby -e 'spec = Gem::Specification.load(\"trusty_cms.gemspec\"); print \"#{spec.name}-#{spec.version}.gem\"')" >> "$GITHUB_ENV"
+          gem build trusty_cms.gemspec
+
+      - name: Publish gem
+        run: gem push "$GEM_FILE"
 
       - name: Remove gem build file
-        run: rm *.gem
+        if: always()
+        run: |
+          if [ -n "${GEM_FILE:-}" ]; then
+            rm -f "$GEM_FILE"
+          fi

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.1.1)
+    trusty-cms (7.1.0)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-cms (7.1.0)
+    trusty-cms (7.1.1)
       RedCloth (= 4.3.3)
       activestorage-validator
       acts_as_list (>= 0.9.5, < 1.3.0)

--- a/lib/trusty_cms/version.rb
+++ b/lib/trusty_cms/version.rb
@@ -1,3 +1,3 @@
 module TrustyCms
-  VERSION = '7.1.1'.freeze
+  VERSION = '7.1.0'.freeze
 end

--- a/trusty_cms.gemspec
+++ b/trusty_cms.gemspec
@@ -3,7 +3,7 @@
 
 require File.expand_path(__FILE__ + '/../lib/trusty_cms/version.rb')
 Gem::Specification.new do |s|
-  s.required_ruby_version = '>= 3.0.5'
+  s.required_ruby_version = '>= 3.3.4'
   s.name = 'trusty-cms'
   s.version = TrustyCms::VERSION
   s.platform = Gem::Platform::RUBY


### PR DESCRIPTION
This pull request updates the build and release workflow for the `trusty-cms` gem, primarily to support Ruby 3.3.4, streamline the publishing process, and increment the gem version. The changes improve automation, security, and compatibility with newer Ruby versions.

**Build and Release Workflow Updates:**

* Updated the GitHub Actions workflow (`.github/workflows/gem-push.yml`) to use Ruby 3.3.4, the latest checkout action, and the `rubygems/configure-rubygems-credentials` action for better credential management. The workflow now separates gem building and publishing steps, and cleans up the built gem file more robustly.
* Changed the required Ruby version in `trusty_cms.gemspec` to `>= 3.3.4` to match the updated workflow and ensure compatibility with the latest Ruby version.

**Version Bump:**

* Incremented the gem version in `lib/trusty_cms/version.rb` from `7.1.0` to `7.1.1` to reflect these updates.