### PR TITLE
Asset thumbnail and URL handling improvements

### DIFF
--- a/app/assets/stylesheets/admin/assets.scss
+++ b/app/assets/stylesheets/admin/assets.scss
@@ -1,3 +1,8 @@
+img.preview {
+  max-width: 300px;
+  max-height: 300px;
+}
+
 .ck-content .asset-image-tag {
   background-color: #dcdcdc;
   display: inline-flex;

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -99,7 +99,10 @@ class Asset < ActiveRecord::Base
   end
 
   def render_original(_style_name)
-    asset.attached? && asset.key.include?('culturaldistrict')
+    return false unless asset.attached?
+
+    prefix = TrustyCms::Config['assets.storage.prefix'].presence
+    prefix ? asset.key.start_with?(prefix) : asset.key.include?('/')
   end
 
   def asset_variant(style_name)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -75,6 +75,8 @@ class Asset < ActiveRecord::Base
            to: :asset_type
 
   def thumbnail(style_name = 'normal')
+    return rewrite_cloud_url(asset.url) if asset.attached? && content_type == 'application/pdf'
+
     variant = asset_variant(style_name.to_s)
     return rewrite_cloud_url(variant.processed.url) if variant
 
@@ -96,8 +98,8 @@ class Asset < ActiveRecord::Base
     %w[asset_content_type asset_file_name asset_file_size caption created_at created_by_id id original_extension original_height original_width title updated_at updated_by_id uuid]
   end
 
-  def render_original(style_name)
-    style_name.to_s == 'original' && asset.attached? && asset.key.include?('culturaldistrict')
+  def render_original(_style_name)
+    asset.attached? && asset.key.include?('culturaldistrict')
   end
 
   def asset_variant(style_name)

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -106,11 +106,11 @@ RSpec.describe Asset, type: :model do
       asset = described_class.new(caption: '')
       allow(asset).to receive_message_chain(:asset, :attached?).and_return(true)
       allow(asset).to receive(:content_type).and_return('application/pdf')
-      allow(asset).to receive_message_chain(:asset, :url).and_return('https://s3.amazonaws.com/bucket/culturaldistrict/system/assets/20260501/doc-abc123.pdf')
+      allow(asset).to receive_message_chain(:asset, :url).and_return('https://s3.amazonaws.com/bucket/myprefix/system/assets/20260501/doc-abc123.pdf')
       allow(asset).to receive(:rewrite_cloud_url) { |url| url }
 
       expect(asset).not_to receive(:asset_variant)
-      expect(asset.thumbnail('normal')).to eq('https://s3.amazonaws.com/bucket/culturaldistrict/system/assets/20260501/doc-abc123.pdf')
+      expect(asset.thumbnail('normal')).to eq('https://s3.amazonaws.com/bucket/myprefix/system/assets/20260501/doc-abc123.pdf')
     end
 
     it 'returns the asset type icon when nothing is attached' do
@@ -124,20 +124,31 @@ RSpec.describe Asset, type: :model do
   end
 
   describe '#render_original' do
-    it 'returns true for any style when the asset key includes culturaldistrict' do
+    it 'returns true for any style when the asset key starts with the configured prefix' do
       asset = described_class.new
+      allow(TrustyCms::Config).to receive(:[]).with('assets.storage.prefix').and_return('myprefix')
       allow(asset).to receive_message_chain(:asset, :attached?).and_return(true)
-      allow(asset).to receive_message_chain(:asset, :key).and_return('culturaldistrict/system/assets/20260501/image-abc123.jpg')
+      allow(asset).to receive_message_chain(:asset, :key).and_return('myprefix/system/assets/20260501/image-abc123.jpg')
 
       expect(asset.render_original('normal')).to be(true)
       expect(asset.render_original('thumbnail')).to be(true)
       expect(asset.render_original('original')).to be(true)
     end
 
-    it 'returns false when the asset key does not include culturaldistrict' do
+    it 'returns true when no prefix is configured but the key contains a path separator' do
       asset = described_class.new
+      allow(TrustyCms::Config).to receive(:[]).with('assets.storage.prefix').and_return(nil)
       allow(asset).to receive_message_chain(:asset, :attached?).and_return(true)
-      allow(asset).to receive_message_chain(:asset, :key).and_return('tsiv1vf6ythpr2waibv99r01d6zq')
+      allow(asset).to receive_message_chain(:asset, :key).and_return('system/assets/20260501/image-abc123.jpg')
+
+      expect(asset.render_original('normal')).to be(true)
+    end
+
+    it 'returns false when the key does not start with the configured prefix' do
+      asset = described_class.new
+      allow(TrustyCms::Config).to receive(:[]).with('assets.storage.prefix').and_return('myprefix')
+      allow(asset).to receive_message_chain(:asset, :attached?).and_return(true)
+      allow(asset).to receive_message_chain(:asset, :key).and_return('randomlegacykey')
 
       expect(asset.render_original('normal')).to be(false)
     end
@@ -151,7 +162,7 @@ RSpec.describe Asset, type: :model do
   end
 
   describe '#public_url' do
-    let(:original_url) { 'https://s3.amazonaws.com/bucket/culturaldistrict/system/assets/20260501/image-abc123.jpg' }
+    let(:original_url) { 'https://s3.amazonaws.com/bucket/myprefix/system/assets/20260501/image-abc123.jpg' }
     let(:variant_url)  { 'https://s3.amazonaws.com/bucket/variants/abc/xyz.jpg' }
 
     it 'returns the original url for new-style assets regardless of style' do
@@ -188,10 +199,10 @@ RSpec.describe Asset, type: :model do
       asset = described_class.new
       allow(asset).to receive(:render_original).and_return(false)
       allow(asset).to receive(:asset_variant).and_return(nil)
-      allow(asset).to receive_message_chain(:asset, :url).and_return('https://s3.amazonaws.com/bucket/tsiv1vf6ythpr2waibv99r01d6zq')
+      allow(asset).to receive_message_chain(:asset, :url).and_return('https://s3.amazonaws.com/bucket/randomlegacykey')
       allow(asset).to receive(:rewrite_cloud_url) { |url| url }
 
-      expect(asset.public_url('normal')).to eq('https://s3.amazonaws.com/bucket/tsiv1vf6ythpr2waibv99r01d6zq')
+      expect(asset.public_url('normal')).to eq('https://s3.amazonaws.com/bucket/randomlegacykey')
     end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -101,5 +101,97 @@ RSpec.describe Asset, type: :model do
 
       expect(asset.thumbnail('thumbnail')).to eq('/rails/active_storage/variant/test')
     end
+
+    it 'returns the direct asset url for pdfs without variant processing' do
+      asset = described_class.new(caption: '')
+      allow(asset).to receive_message_chain(:asset, :attached?).and_return(true)
+      allow(asset).to receive(:content_type).and_return('application/pdf')
+      allow(asset).to receive_message_chain(:asset, :url).and_return('https://s3.amazonaws.com/bucket/culturaldistrict/system/assets/20260501/doc-abc123.pdf')
+      allow(asset).to receive(:rewrite_cloud_url) { |url| url }
+
+      expect(asset).not_to receive(:asset_variant)
+      expect(asset.thumbnail('normal')).to eq('https://s3.amazonaws.com/bucket/culturaldistrict/system/assets/20260501/doc-abc123.pdf')
+    end
+
+    it 'returns the asset type icon when nothing is attached' do
+      asset = described_class.new(caption: '')
+      allow(asset).to receive_message_chain(:asset, :attached?).and_return(false)
+      allow(asset).to receive(:asset_variant).and_return(nil)
+      allow(asset).to receive_message_chain(:asset_type, :icon).with('normal').and_return('/assets/admin/image_icon.png')
+
+      expect(asset.thumbnail('normal')).to eq('/assets/admin/image_icon.png')
+    end
+  end
+
+  describe '#render_original' do
+    it 'returns true for any style when the asset key includes culturaldistrict' do
+      asset = described_class.new
+      allow(asset).to receive_message_chain(:asset, :attached?).and_return(true)
+      allow(asset).to receive_message_chain(:asset, :key).and_return('culturaldistrict/system/assets/20260501/image-abc123.jpg')
+
+      expect(asset.render_original('normal')).to be(true)
+      expect(asset.render_original('thumbnail')).to be(true)
+      expect(asset.render_original('original')).to be(true)
+    end
+
+    it 'returns false when the asset key does not include culturaldistrict' do
+      asset = described_class.new
+      allow(asset).to receive_message_chain(:asset, :attached?).and_return(true)
+      allow(asset).to receive_message_chain(:asset, :key).and_return('tsiv1vf6ythpr2waibv99r01d6zq')
+
+      expect(asset.render_original('normal')).to be(false)
+    end
+
+    it 'returns false when no asset is attached' do
+      asset = described_class.new
+      allow(asset).to receive_message_chain(:asset, :attached?).and_return(false)
+
+      expect(asset.render_original('normal')).to be(false)
+    end
+  end
+
+  describe '#public_url' do
+    let(:original_url) { 'https://s3.amazonaws.com/bucket/culturaldistrict/system/assets/20260501/image-abc123.jpg' }
+    let(:variant_url)  { 'https://s3.amazonaws.com/bucket/variants/abc/xyz.jpg' }
+
+    it 'returns the original url for new-style assets regardless of style' do
+      asset = described_class.new
+      allow(asset).to receive(:render_original).and_return(true)
+      allow(asset).to receive_message_chain(:asset, :url).and_return(original_url)
+      allow(asset).to receive(:rewrite_cloud_url) { |url| url }
+
+      expect(asset.public_url('normal')).to eq(original_url)
+      expect(asset.public_url('thumbnail')).to eq(original_url)
+    end
+
+    it 'returns the original url when style_name is original' do
+      asset = described_class.new
+      allow(asset).to receive(:render_original).and_return(false)
+      allow(asset).to receive_message_chain(:asset, :url).and_return(original_url)
+      allow(asset).to receive(:rewrite_cloud_url) { |url| url }
+
+      expect(asset.public_url('original')).to eq(original_url)
+    end
+
+    it 'returns a variant url for old-style assets' do
+      asset = described_class.new
+      allow(asset).to receive(:render_original).and_return(false)
+      processed = instance_double(ActiveStorage::Variant, url: variant_url)
+      variant   = instance_double(ActiveStorage::Variant, processed: processed)
+      allow(asset).to receive(:asset_variant).and_return(variant)
+      allow(asset).to receive(:rewrite_cloud_url) { |url| url }
+
+      expect(asset.public_url('normal')).to eq(variant_url)
+    end
+
+    it 'falls back to the asset url when no variant exists for an old-style asset' do
+      asset = described_class.new
+      allow(asset).to receive(:render_original).and_return(false)
+      allow(asset).to receive(:asset_variant).and_return(nil)
+      allow(asset).to receive_message_chain(:asset, :url).and_return('https://s3.amazonaws.com/bucket/tsiv1vf6ythpr2waibv99r01d6zq')
+      allow(asset).to receive(:rewrite_cloud_url) { |url| url }
+
+      expect(asset.public_url('normal')).to eq('https://s3.amazonaws.com/bucket/tsiv1vf6ythpr2waibv99r01d6zq')
+    end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1735,9 +1735,9 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.2.9:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
-  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 fs.realpath@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2961,9 +2961,9 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 postcss-html@^0.36.0:
   version "0.36.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2262,9 +2262,9 @@ lodash.truncate@^4.4.2:
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
This pull request improves how asset thumbnails and URLs are handled, especially for PDF files and assets stored with "culturaldistrict" keys. It also adds and updates tests to ensure the new logic works as intended and introduces a style update for image previews in the admin interface.

**Asset thumbnail and URL handling improvements:**

* Updated the `thumbnail` method in `Asset` to return the direct asset URL for PDFs without attempting variant processing, ensuring PDFs are handled correctly.
* Simplified the `render_original` method to ignore the style name and only check if the asset is attached and the key includes "culturaldistrict", improving clarity and consistency.

**Testing improvements:**

* Added comprehensive tests for the `thumbnail`, `render_original`, and `public_url` methods in `asset_spec.rb`, covering PDF handling, asset type icon fallback, and various asset storage scenarios.

**Admin UI styling:**

* Added a CSS rule to limit the maximum width and height of images with the `preview` class to 300px in the admin interface, improving image display consistency.