### PR TITLE
Update spec coverage report for accuracy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,10 @@ jobs:
       - run:
           name: Run tests with coverage
           command: |
-            bundle exec rspec --format progress -o /tmp/test-results/rspec.xml --profile 10 $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            bundle exec rspec --profile 10 \
+              --format progress \
+              --format RspecJunitFormatter --out /tmp/test-results/rspec.xml \
+              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
           when: always
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           path: /tmp/test-results
           destination: test-results
 
-      - qlty-orb/coverage_publish:
+      - qlty/coverage_publish:
           files: coverage/coverage.json
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,8 +82,8 @@ jobs:
           path: /tmp/test-results
           destination: test-results
 
-      - qlty/coverage_publish:
-          files: coverage/lcov.info
+      - qlty-orb/coverage_publish:
+          files: coverage/coverage.json
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
             bundle exec rspec --profile 10 \
               --format progress \
               --format RspecJunitFormatter --out /tmp/test-results/rspec.xml \
+              --format html --out /tmp/test-results/rspec.html \
               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
           when: always
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,8 @@ group :development, :test do
   gem 'psych', '5.2.2'
   gem 'rails-observers'
   gem 'ransack'
-  gem 'rspec-rails', '~> 7.1.1'
   gem 'rspec_junit_formatter'
+  gem 'rspec-rails', '~> 7.1.1'
   gem 'simplecov'
   gem 'simplecov-lcov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem 'rails-observers'
   gem 'ransack'
   gem 'rspec-rails', '~> 7.1.1'
+  gem 'rspec_junit_formatter'
   gem 'simplecov'
   gem 'simplecov-lcov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,6 +415,8 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.4)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)
       logger
@@ -499,6 +501,7 @@ DEPENDENCIES
   rails-observers
   ransack
   rspec-rails (~> 7.1.1)
+  rspec_junit_formatter
   simplecov
   simplecov-lcov
   trusty-cms!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
-# Coverage setup
+# Coverage setup — MUST run before any application code is loaded,
+# otherwise Ruby's Coverage library never sees files loaded at boot.
 require 'simplecov'
 require 'simplecov-lcov'
 
@@ -11,8 +11,14 @@ SimpleCov::Formatter::LcovFormatter.config do |config|
   config.lcov_file_name = 'lcov.info'
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::LcovFormatter,
+  SimpleCov::Formatter::HTMLFormatter
+])
 SimpleCov.start('rails')
+
+# Now load the application — everything required below is tracked.
+require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
 # Test framework setup
 require 'rspec/rails'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ ENV['RAILS_ENV'] ||= 'test'
 # otherwise Ruby's Coverage library never sees files loaded at boot.
 require 'simplecov'
 require 'simplecov-lcov'
+require 'simplecov_json_formatter'
 
 SimpleCov::Formatter::LcovFormatter.config do |config|
   config.report_with_single_file = true
@@ -18,6 +19,7 @@ SimpleCov.configure do
 end
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::JSONFormatter,   # coverage/coverage.json — consumed by qlty
   SimpleCov::Formatter::LcovFormatter,
   SimpleCov::Formatter::HTMLFormatter
 ])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,12 @@ SimpleCov::Formatter::LcovFormatter.config do |config|
   config.lcov_file_name = 'lcov.info'
 end
 
+SimpleCov.configure do
+  add_filter %r{^/lib/generators/}
+  add_filter 'lib/trusty_cms/setup.rb'
+  add_filter %r{/templates/}   # generated-app boilerplate
+end
+
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::LcovFormatter,
   SimpleCov::Formatter::HTMLFormatter


### PR DESCRIPTION
This pull request updates the test coverage setup in `spec/spec_helper.rb` to improve accuracy of the lcov file. The main changes ensure that code coverage is measured correctly and that coverage reports are more useful.

**Test Coverage Improvements:**

* Moved the `SimpleCov` setup to run before any application code is loaded, ensuring all files are tracked by the coverage tool.
* Added coverage filters in the `SimpleCov.configure` block to exclude generated files, setup scripts, and boilerplate templates from coverage reports.

**Coverage Reporting Enhancements:**

* Switched to using `SimpleCov::Formatter::MultiFormatter` to generate both LCOV and HTML coverage reports, making it easier to view and integrate results.
* Moved the application environment load (`require File.expand_path('../dummy/config/environment.rb', __FILE__)`) to after coverage setup, so coverage tracking includes all loaded files. [[1]](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94L2-R4) [[2]](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94L14-R28)