### PR TITLE
Standard tags specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,10 @@ jobs:
       - run:
           name: Run tests with coverage
           command: |
-            bundle exec rspec --format progress -o /tmp/test-results/rspec.xml --profile 10 $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            bundle exec rspec --profile 10 \
+              --format progress \
+              --format RspecJunitFormatter --out /tmp/test-results/rspec.xml \
+              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
           when: always
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           path: /tmp/test-results
           destination: test-results
 
-      - qlty-orb/coverage_publish:
+      - qlty/coverage_publish:
           files: coverage/coverage.json
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,8 +82,8 @@ jobs:
           path: /tmp/test-results
           destination: test-results
 
-      - qlty/coverage_publish:
-          files: coverage/lcov.info
+      - qlty-orb/coverage_publish:
+          files: coverage/coverage.json
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
             bundle exec rspec --profile 10 \
               --format progress \
               --format RspecJunitFormatter --out /tmp/test-results/rspec.xml \
+              --format html --out /tmp/test-results/rspec.html \
               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
           when: always
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,8 @@ group :development, :test do
   gem 'psych', '5.2.2'
   gem 'rails-observers'
   gem 'ransack'
-  gem 'rspec-rails', '~> 7.1.1'
   gem 'rspec_junit_formatter'
+  gem 'rspec-rails', '~> 7.1.1'
   gem 'simplecov'
   gem 'simplecov-lcov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem 'rails-observers'
   gem 'ransack'
   gem 'rspec-rails', '~> 7.1.1'
+  gem 'rspec_junit_formatter'
   gem 'simplecov'
   gem 'simplecov-lcov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,6 +415,8 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.4)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)
       logger
@@ -499,6 +501,7 @@ DEPENDENCIES
   rails-observers
   ransack
   rspec-rails (~> 7.1.1)
+  rspec_junit_formatter
   simplecov
   simplecov-lcov
   trusty-cms!

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Rails engine and is built to be installed into an existing Rails 7 application a
 
 CircleCI: [![CircleCI](https://circleci.com/gh/pgharts/trusty-cms/tree/master.svg?style=shield)](https://circleci.com/gh/pgharts/trusty-cms/tree/master)
 
+Coverage: [![Coverage](https://qlty.sh/badges/4cf4f7cc-d0e8-4559-93ec-685866f5645b/test_coverage.svg)](https://qlty.sh/gh/pgharts/projects/trusty-cms) 
+
 Qlty: [![Maintainability](https://qlty.sh/gh/pgharts/projects/trusty-cms/maintainability.svg)](https://qlty.sh/gh/pgharts/projects/trusty-cms)
 
 TrustyCMS features:

--- a/spec/models/standard_tags_spec.rb
+++ b/spec/models/standard_tags_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'Standard Tags' do
+  # Helper: render a radius string in the context of the given page.
+  def render(page, input)
+    page.send(:parse, input)
+  end
+
+  let(:home) do
+    FactoryBot.create(:home, title: 'Home', breadcrumb: 'Home')
+  end
+
+  describe '<r:page>' do
+    it 'sets the local page to the global page' do
+      expect(render(home, '<r:page><r:title /></r:page>')).to eq('Home')
+    end
+  end
+
+  describe 'attribute tags' do
+    it 'renders <r:title />' do
+      expect(render(home, '<r:title />')).to eq('Home')
+    end
+
+    it 'renders <r:breadcrumb />' do
+      expect(render(home, '<r:breadcrumb />')).to eq('Home')
+    end
+
+    it 'renders <r:slug />' do
+      expect(render(home, '<r:slug />')).to eq('/')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
-# Coverage setup
+# Coverage setup — MUST run before any application code is loaded,
+# otherwise Ruby's Coverage library never sees files loaded at boot.
 require 'simplecov'
 require 'simplecov-lcov'
 
@@ -11,8 +11,14 @@ SimpleCov::Formatter::LcovFormatter.config do |config|
   config.lcov_file_name = 'lcov.info'
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::LcovFormatter,
+  SimpleCov::Formatter::HTMLFormatter
+])
 SimpleCov.start('rails')
+
+# Now load the application — everything required below is tracked.
+require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
 # Test framework setup
 require 'rspec/rails'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ ENV['RAILS_ENV'] ||= 'test'
 # otherwise Ruby's Coverage library never sees files loaded at boot.
 require 'simplecov'
 require 'simplecov-lcov'
+require 'simplecov_json_formatter'
 
 SimpleCov::Formatter::LcovFormatter.config do |config|
   config.report_with_single_file = true
@@ -18,6 +19,7 @@ SimpleCov.configure do
 end
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::JSONFormatter,   # coverage/coverage.json — consumed by qlty
   SimpleCov::Formatter::LcovFormatter,
   SimpleCov::Formatter::HTMLFormatter
 ])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,12 @@ SimpleCov::Formatter::LcovFormatter.config do |config|
   config.lcov_file_name = 'lcov.info'
 end
 
+SimpleCov.configure do
+  add_filter %r{^/lib/generators/}
+  add_filter 'lib/trusty_cms/setup.rb'
+  add_filter %r{/templates/}   # generated-app boilerplate
+end
+
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::LcovFormatter,
   SimpleCov::Formatter::HTMLFormatter


### PR DESCRIPTION
This pull request adds new tests for standard tags and introduces a temporary support file to help diagnose order-dependent asset type registration issues in the test suite.

### New and Improved Tests

* Added `spec/models/standard_tags_spec.rb` to test rendering of standard page tags such as `<r:title />`, `<r:breadcrumb />`, and `<r:slug />`, ensuring they return expected values.

### Test Suite Diagnostics

* Introduced `spec/support/zzz_contaminate_asset_type.rb`, which temporarily registers the `:image` asset type with additional extensions and MIME types before the test suite runs, to help reproduce and diagnose order-dependent asset spec failures.