### PR TITLE
Standard tags spec

### DIFF
--- a/app/models/standard_tags.rb
+++ b/app/models/standard_tags.rb
@@ -52,8 +52,7 @@ module StandardTags
   }
   tag 'children:count' do |tag|
     options = children_find_options(tag)
-    options.delete(:order) # Order is irrelevant
-    tag.locals.children.count(options)
+    tag.locals.children.where(options[:conditions]).count
   end
 
   desc %{
@@ -66,7 +65,7 @@ module StandardTags
   }
   tag 'children:first' do |tag|
     options = children_find_options(tag)
-    children = tag.locals.children.where(options)
+    children = tag.locals.children.where(options[:conditions]).order(options[:order])
     if first = children.first
       tag.locals.page = first
       tag.expand
@@ -83,7 +82,7 @@ module StandardTags
   }
   tag 'children:last' do |tag|
     options = children_find_options(tag)
-    children = tag.locals.children.where(options)
+    children = tag.locals.children.where(options[:conditions]).order(options[:order])
     if last = children.last
       tag.locals.page = last
       tag.expand
@@ -942,7 +941,14 @@ module StandardTags
     paging = pagination_find_options(tag)
     result = []
     tag.locals.previous_headers = {}
-    displayed_children = paging ? findable.paginate(options.merge(paging)) : findable.all.where(options[:conditions]).order(options[:order])
+    scoped = findable.where(options[:conditions]).order(options[:order])
+    if paging
+      displayed_children = scoped.paginate(paging)
+    else
+      scoped = scoped.limit(options[:limit]) if options[:limit]
+      scoped = scoped.offset(options[:offset]) if options[:offset]
+      displayed_children = scoped
+    end
     displayed_children.each_with_index do |item, i|
       tag.locals.child = item
       tag.locals.page = item
@@ -989,13 +995,13 @@ module StandardTags
 
     status = attr[:status]
     if status == 'all'
-      options[:conditions] = ['virtual = ?', false]
+      options[:conditions] = ['`virtual` = ?', false]
     else
       stat = Status[status]
       if stat.nil?
         raise TagError.new(%{`status' attribute of `each' tag must be set to a valid status})
       else
-        options[:conditions] = ['(virtual = ?) and (status_id = ?)', false, stat.id]
+        options[:conditions] = ['(`virtual` = ?) and (status_id = ?)', false, stat.id]
       end
     end
     options

--- a/spec/models/standard_tags/children_spec.rb
+++ b/spec/models/standard_tags/children_spec.rb
@@ -1,0 +1,159 @@
+require 'spec_helper'
+
+describe 'StandardTags: children tags' do
+  def render(page, input)
+    page.send(:parse, input)
+  end
+
+  let(:home) { FactoryBot.create(:home) }
+
+  # Three published children (ascending published_at) plus one draft, so we can
+  # exercise ordering, status filtering, limit/offset and pagination.
+  before do
+    FactoryBot.create(:page, title: 'Apple',  slug: 'apple',  parent: home, status_id: Status[:published].id, published_at: Time.zone.local(2020, 1, 1))
+    FactoryBot.create(:page, title: 'Banana', slug: 'banana', parent: home, status_id: Status[:published].id, published_at: Time.zone.local(2020, 1, 2))
+    FactoryBot.create(:page, title: 'Cherry', slug: 'cherry', parent: home, status_id: Status[:published].id, published_at: Time.zone.local(2020, 1, 3))
+    FactoryBot.create(:page, title: 'Zeta',   slug: 'zeta',   parent: home, status_id: Status[:draft].id)
+  end
+
+  describe '<r:children>' do
+    it 'expands its contents' do
+      expect(render(home, '<r:children>hello</r:children>')).to eq('hello')
+    end
+  end
+
+  describe '<r:children:count>' do
+    it 'counts published children by default status' do
+      expect(render(home, '<r:children:count status="published" />')).to eq('3')
+    end
+
+    it 'counts all non-virtual children with status="all"' do
+      expect(render(home, '<r:children:count status="all" />')).to eq('4')
+    end
+  end
+
+  describe '<r:children:each>' do
+    it 'iterates published children ordered by published_at ascending' do
+      expect(render(home, '<r:children:each status="published"><r:title /> </r:children:each>'))
+        .to eq('Apple Banana Cherry ')
+    end
+
+    it 'orders by a given field and direction' do
+      expect(render(home, '<r:children:each status="published" by="title" order="desc"><r:title /> </r:children:each>'))
+        .to eq('Cherry Banana Apple ')
+    end
+
+    it 'honors the limit attribute' do
+      expect(render(home, '<r:children:each status="published" by="title" limit="2"><r:title /> </r:children:each>'))
+        .to eq('Apple Banana ')
+    end
+
+    it 'honors the offset attribute' do
+      expect(render(home, '<r:children:each status="published" by="title" offset="1"><r:title /> </r:children:each>'))
+        .to eq('Banana Cherry ')
+    end
+
+    it 'includes non-virtual draft pages with status="all"' do
+      expect(render(home, '<r:children:each status="all" by="title"><r:title /> </r:children:each>'))
+        .to eq('Apple Banana Cherry Zeta ')
+    end
+
+    it 'raises when the by attribute is not a valid field' do
+      expect { render(home, '<r:children:each status="published" by="bogus"><r:title /></r:children:each>') }
+        .to raise_error(StandardTags::TagError, /`by'/)
+    end
+
+    it 'raises when the order attribute is invalid' do
+      expect { render(home, '<r:children:each status="published" order="sideways"><r:title /></r:children:each>') }
+        .to raise_error(StandardTags::TagError, /`order'/)
+    end
+
+    it 'raises when the status attribute is not a valid status' do
+      expect { render(home, '<r:children:each status="bogus"><r:title /></r:children:each>') }
+        .to raise_error(StandardTags::TagError, /`status'/)
+    end
+
+    it 'raises when the status attribute is omitted' do
+      expect { render(home, '<r:children:each><r:title /></r:children:each>') }
+        .to raise_error(StandardTags::TagError, /`status'/)
+    end
+
+    it 'raises when limit is not a positive number' do
+      expect { render(home, '<r:children:each status="published" limit="x"><r:title /></r:children:each>') }
+        .to raise_error(StandardTags::TagError, /limit/)
+    end
+  end
+
+  describe 'child context tags inside <r:children:each>' do
+    it 'maps <r:child> attribute tags to the current child' do
+      expect(render(home, '<r:children:each status="published" by="title"><r:child><r:title /></r:child> </r:children:each>'))
+        .to eq('Apple Banana Cherry ')
+    end
+
+    it 'renders <r:if_first> only for the first child' do
+      expect(render(home, '<r:children:each status="published" by="title"><r:if_first>[first]</r:if_first><r:title /> </r:children:each>'))
+        .to eq('[first]Apple Banana Cherry ')
+    end
+
+    it 'renders <r:unless_first> for every child but the first' do
+      expect(render(home, '<r:children:each status="published" by="title"><r:unless_first>, </r:unless_first><r:title /></r:children:each>'))
+        .to eq('Apple, Banana, Cherry')
+    end
+
+    it 'renders <r:if_last> only for the last child' do
+      expect(render(home, '<r:children:each status="published" by="title"><r:title /><r:if_last>[last]</r:if_last> </r:children:each>'))
+        .to eq('Apple Banana Cherry[last] ')
+    end
+
+    it 'renders <r:unless_last> for every child but the last' do
+      expect(render(home, '<r:children:each status="published" by="title"><r:title /><r:unless_last>, </r:unless_last></r:children:each>'))
+        .to eq('Apple, Banana, Cherry')
+    end
+
+    it 'renders a header only when it changes' do
+      # A constant header renders once (before the first child) then is suppressed.
+      expect(render(home, '<r:children:each status="published" by="title"><r:header>H</r:header><r:title /> </r:children:each>'))
+        .to eq('HApple Banana Cherry ')
+    end
+  end
+
+  describe '<r:children:first> and <r:children:last>' do
+    it 'renders the first child (by published_at)' do
+      expect(render(home, '<r:children:first status="published"><r:title /></r:children:first>')).to eq('Apple')
+    end
+
+    it 'renders the last child (by published_at)' do
+      expect(render(home, '<r:children:last status="published"><r:title /></r:children:last>')).to eq('Cherry')
+    end
+
+    it 'respects ordering options when picking the first child' do
+      expect(render(home, '<r:children:first status="published" by="title" order="desc"><r:title /></r:children:first>')).to eq('Cherry')
+    end
+  end
+
+  describe 'pagination' do
+    # The pagination *controls* are rendered by the will_paginate view helper,
+    # which needs a view context that a model-level parse does not have, so we
+    # stub that layer and assert the results-slicing behavior of the tag.
+    before do
+      allow(home).to receive(:will_paginate).and_return('[controls]')
+      allow(home).to receive(:will_paginate_options).and_return({})
+    end
+
+    it 'renders only the current page of children plus pagination controls' do
+      home.pagination_parameters = { page: 1, per_page: 2 }
+      expect(render(home, '<r:children:each status="published" by="title" paginated="true" per_page="2"><r:title /> </r:children:each>'))
+        .to eq('Apple Banana [controls]')
+    end
+
+    it 'renders the second page of children' do
+      home.pagination_parameters = { page: 2, per_page: 2 }
+      expect(render(home, '<r:children:each status="published" by="title" paginated="true" per_page="2"><r:title /> </r:children:each>'))
+        .to eq('Cherry [controls]')
+    end
+
+    it 'renders nothing for the standalone pagination tag when there is no paginated list' do
+      expect(render(home, '<r:pagination />')).to eq('')
+    end
+  end
+end

--- a/spec/models/standard_tags/content_spec.rb
+++ b/spec/models/standard_tags/content_spec.rb
@@ -1,0 +1,168 @@
+require 'spec_helper'
+
+describe 'StandardTags: <r:content>' do
+  # Render radius markup in the context of the given page.
+  def render(page, input)
+    page.send(:parse, input)
+  end
+
+  let(:page) { FactoryBot.create(:page, title: 'Home') }
+
+  # 1. Happy path: renders the default `body` part.
+  it 'renders the body part by default' do
+    page.parts.create(name: 'body', content: 'Hello world')
+    expect(render(page, '<r:content />')).to eq('Hello world')
+  end
+
+  # 2. Named part via the `part` attribute.
+  it 'renders a named part when given the part attribute' do
+    page.parts.create(name: 'sidebar', content: 'Sidebar text')
+    expect(render(page, '<r:content part="sidebar" />')).to eq('Sidebar text')
+  end
+
+  # 3. Missing part -> `part` is nil -> renders empty (line 500 leaves result nil).
+  it 'renders nothing when the requested part does not exist' do
+    expect(render(page, '<r:content part="nonexistent" />')).to eq('')
+  end
+
+  # 7. Nested radius tags inside the part are parsed by render_snippet.
+  it 'parses radius tags contained in the part' do
+    page.parts.create(name: 'body', content: 'Title is <r:title />')
+    expect(render(page, '<r:content />')).to eq('Title is Home')
+  end
+
+  describe 'inherit' do
+    let(:parent) { FactoryBot.create(:page, title: 'Parent') }
+    let(:child)  { FactoryBot.create(:page, title: 'Child', parent: parent) }
+
+    before { parent.parts.create(name: 'body', content: 'Parent body') }
+
+    # 4. inherit="true" walks up to the parent's part.
+    it 'renders an inherited part from the parent when inherit is true' do
+      expect(render(child, '<r:content inherit="true" />')).to eq('Parent body')
+    end
+
+    # 5. Default (inherit=false) does not walk up.
+    it 'renders nothing when the part is missing and inherit is false' do
+      expect(render(child, '<r:content />')).to eq('')
+    end
+  end
+
+  # 6. Recursion guard raises TagError (errors are raised in the test env).
+  it 'raises a TagError on recursive rendering of the same part' do
+    page.parts.create(name: 'body', content: 'loop <r:content />')
+    expect { render(page, '<r:content />') }
+      .to raise_error(StandardTags::TagError, /Recursion error/)
+  end
+
+  # 8. A non-boolean value for a boolean attribute raises TagError.
+  it 'raises a TagError when inherit is not a boolean' do
+    page.parts.create(name: 'body', content: 'Hello')
+    expect { render(page, '<r:content inherit="maybe" />') }
+      .to raise_error(StandardTags::TagError)
+  end
+end
+
+describe 'StandardTags: <r:if_content>' do
+  def render(page, input)
+    page.send(:parse, input)
+  end
+
+  let(:page) { FactoryBot.create(:page, title: 'Home') }
+
+  it 'expands when the default body part exists' do
+    page.parts.create(name: 'body', content: 'x')
+    expect(render(page, '<r:if_content>shown</r:if_content>')).to eq('shown')
+  end
+
+  it 'does not expand when the part is missing' do
+    expect(render(page, '<r:if_content>shown</r:if_content>')).to eq('')
+  end
+
+  describe 'multiple parts' do
+    before { page.parts.create(name: 'body', content: 'x') }
+
+    it 'find="all" (default) does not expand when one listed part is missing' do
+      expect(render(page, '<r:if_content part="body, sidebar">shown</r:if_content>')).to eq('')
+    end
+
+    it 'find="all" expands when every listed part exists' do
+      page.parts.create(name: 'sidebar', content: 'y')
+      expect(render(page, '<r:if_content part="body, sidebar">shown</r:if_content>')).to eq('shown')
+    end
+
+    it 'find="any" expands when at least one listed part exists' do
+      expect(render(page, '<r:if_content part="body, sidebar" find="any">shown</r:if_content>')).to eq('shown')
+    end
+  end
+
+  describe 'inherit' do
+    let(:parent) { FactoryBot.create(:page, title: 'Parent') }
+    let(:child)  { FactoryBot.create(:page, title: 'Child', parent: parent) }
+
+    before { parent.parts.create(name: 'body', content: 'Parent body') }
+
+    it 'expands when an ancestor has the part and inherit is true' do
+      expect(render(child, '<r:if_content inherit="true">shown</r:if_content>')).to eq('shown')
+    end
+
+    it 'does not expand for an inherited part when inherit is false' do
+      expect(render(child, '<r:if_content>shown</r:if_content>')).to eq('')
+    end
+  end
+
+  it 'raises a TagError for an invalid find value' do
+    page.parts.create(name: 'body', content: 'x')
+    expect { render(page, '<r:if_content find="bogus">shown</r:if_content>') }
+      .to raise_error(StandardTags::TagError)
+  end
+end
+
+describe 'StandardTags: <r:unless_content>' do
+  def render(page, input)
+    page.send(:parse, input)
+  end
+
+  let(:page) { FactoryBot.create(:page, title: 'Home') }
+
+  it 'expands when the default body part is missing' do
+    expect(render(page, '<r:unless_content>shown</r:unless_content>')).to eq('shown')
+  end
+
+  it 'does not expand when the part exists' do
+    page.parts.create(name: 'body', content: 'x')
+    expect(render(page, '<r:unless_content>shown</r:unless_content>')).to eq('')
+  end
+
+  describe 'multiple parts' do
+    before { page.parts.create(name: 'body', content: 'x') }
+
+    it 'find="all" (default) expands when at least one listed part is missing' do
+      expect(render(page, '<r:unless_content part="body, sidebar">shown</r:unless_content>')).to eq('shown')
+    end
+
+    it 'find="any" does not expand when any listed part is found' do
+      expect(render(page, '<r:unless_content part="body, sidebar" find="any">shown</r:unless_content>')).to eq('')
+    end
+
+    it 'find="any" expands when none of the listed parts exist' do
+      expect(render(page, '<r:unless_content part="header, sidebar" find="any">shown</r:unless_content>')).to eq('shown')
+    end
+  end
+
+  describe 'inherit' do
+    let(:parent) { FactoryBot.create(:page, title: 'Parent') }
+    let(:child)  { FactoryBot.create(:page, title: 'Child', parent: parent) }
+
+    before { parent.parts.create(name: 'body', content: 'Parent body') }
+
+    it 'does not expand when an ancestor has the part and inherit is true' do
+      expect(render(child, '<r:unless_content inherit="true">shown</r:unless_content>')).to eq('')
+    end
+  end
+
+  it 'raises a TagError for an invalid find value' do
+    expect { render(page, '<r:unless_content find="bogus">shown</r:unless_content>') }
+      .to raise_error(StandardTags::TagError)
+  end
+end

--- a/spec/models/standard_tags/meta_spec.rb
+++ b/spec/models/standard_tags/meta_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe 'StandardTags: <r:meta>' do
+  def render(page, input)
+    page.send(:parse, input)
+  end
+
+  let(:page) { FactoryBot.create(:page, title: 'Home') }
+
+  describe '<r:meta:description>' do
+    it 'wraps the description field in a meta element by default' do
+      page.fields.create(name: 'description', content: 'A page')
+      expect(render(page, '<r:meta:description />'))
+        .to eq('<meta name="description" content="A page" />')
+    end
+
+    it 'escapes HTML in the description content' do
+      page.fields.create(name: 'description', content: 'Tom & Jerry <b>')
+      expect(render(page, '<r:meta:description />'))
+        .to eq('<meta name="description" content="Tom &amp; Jerry &lt;b&gt;" />')
+    end
+
+    it 'returns the raw (escaped) content without a wrapper when tag="false"' do
+      page.fields.create(name: 'description', content: 'Tom & Jerry')
+      expect(render(page, '<r:meta:description tag="false" />')).to eq('Tom &amp; Jerry')
+    end
+
+    it 'renders an empty content element when there is no description field' do
+      expect(render(page, '<r:meta:description />'))
+        .to eq('<meta name="description" content="" />')
+    end
+  end
+
+  describe '<r:meta:keywords>' do
+    it 'wraps the keywords field in a meta element by default' do
+      page.fields.create(name: 'keywords', content: 'ruby, cms')
+      expect(render(page, '<r:meta:keywords />'))
+        .to eq('<meta name="keywords" content="ruby, cms" />')
+    end
+
+    it 'returns the raw (escaped) content without a wrapper when tag="false"' do
+      page.fields.create(name: 'keywords', content: 'a & b')
+      expect(render(page, '<r:meta:keywords tag="false" />')).to eq('a &amp; b')
+    end
+
+    it 'renders an empty content element when there is no keywords field' do
+      expect(render(page, '<r:meta:keywords />'))
+        .to eq('<meta name="keywords" content="" />')
+    end
+  end
+
+  describe '<r:meta>' do
+    it 'concatenates the description and keywords elements when used as a single tag' do
+      page.fields.create(name: 'description', content: 'A page')
+      page.fields.create(name: 'keywords', content: 'ruby')
+      expect(render(page, '<r:meta />'))
+        .to eq('<meta name="description" content="A page" /><meta name="keywords" content="ruby" />')
+    end
+
+    it 'expands its contents when used as a double tag' do
+      expect(render(page, '<r:meta>inner <r:title /></r:meta>')).to eq('inner Home')
+    end
+  end
+end
+
+describe 'StandardTags: <r:site>' do
+  def render(page, input)
+    page.send(:parse, input)
+  end
+
+  let(:page) { FactoryBot.create(:page, title: 'Home') }
+
+  it 'expands the contents of the site container tag' do
+    expect(render(page, '<r:site>content</r:site>')).to eq('content')
+  end
+
+  it 'renders the configured site title' do
+    TrustyCms::Config['site.title'] = 'My Site'
+    expect(render(page, '<r:site:title />')).to eq('My Site')
+  end
+
+  it 'renders the configured site host' do
+    TrustyCms::Config['site.host'] = 'example.com'
+    expect(render(page, '<r:site:host />')).to eq('example.com')
+  end
+end

--- a/spec/models/standard_tags_spec.rb
+++ b/spec/models/standard_tags_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'Standard Tags' do
+  # Helper: render a radius string in the context of the given page.
+  def render(page, input)
+    page.send(:parse, input)
+  end
+
+  let(:home) do
+    FactoryBot.create(:home, title: 'Home', breadcrumb: 'Home')
+  end
+
+  describe '<r:page>' do
+    it 'sets the local page to the global page' do
+      expect(render(home, '<r:page><r:title /></r:page>')).to eq('Home')
+    end
+  end
+
+  describe 'attribute tags' do
+    it 'renders <r:title />' do
+      expect(render(home, '<r:title />')).to eq('Home')
+    end
+
+    it 'renders <r:breadcrumb />' do
+      expect(render(home, '<r:breadcrumb />')).to eq('Home')
+    end
+
+    it 'renders <r:slug />' do
+      expect(render(home, '<r:slug />')).to eq('/')
+    end
+  end
+end


### PR DESCRIPTION
This pull request makes several improvements and fixes to the handling of standard tags in the application, especially around the `children` tags, and adds comprehensive test coverage for standard tags including `children`, `content`, `meta`, and `site` tags. The changes include refactoring query construction for children tags, correcting SQL syntax, and adding new RSpec tests to ensure correct behavior for a variety of tag scenarios.

**Children tag logic and query improvements:**

* Refactored the construction of ActiveRecord queries for `children:count`, `children:first`, and `children:last` tags to explicitly separate conditions and ordering, ensuring correct SQL generation and more predictable results. [[1]](diffhunk://#diff-34bb60d4ee59de3d85db9f8e573cceb8ef72f2de5e071020601204ae021edf27L55-R55) [[2]](diffhunk://#diff-34bb60d4ee59de3d85db9f8e573cceb8ef72f2de5e071020601204ae021edf27L69-R68) [[3]](diffhunk://#diff-34bb60d4ee59de3d85db9f8e573cceb8ef72f2de5e071020601204ae021edf27L86-R85)
* Updated the `render_children_with_pagination` method to apply limit and offset only when pagination is not used, improving the accuracy of result sets.
* Corrected SQL condition syntax in `children_find_options` to use backticks around the `virtual` field, preventing potential SQL errors.

**Test coverage:**

* Added a comprehensive spec for `children` tags, covering counting, iteration, ordering, limiting, offsetting, pagination, error handling, and context tags.
* Added specs for the `content`, `if_content`, and `unless_content` tags, testing default behavior, inheritance, recursion protection, and error handling.
* Introduced specs for the `meta` and `site` tags, verifying correct rendering of meta tags and site configuration values.
* Added a basic spec for standard attribute tags such as `title`, `breadcrumb`, and `slug`.