### PR TITLE
Specs/page

### DIFF
--- a/spec/controllers/site_controller_spec.rb
+++ b/spec/controllers/site_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe SiteController, type: :request do
+  let!(:home) { FactoryBot.create(:home, title: 'Home') }
+
+  before { home.parts.create(name: 'body', content: 'Welcome <r:title />') }
+
+  describe 'serving pages' do
+    it 'renders the home page at the root path' do
+      get '/'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Welcome Home')
+    end
+
+    it 'renders a published child page by its path' do
+      about = FactoryBot.create(:page, title: 'About', slug: 'about', parent: home, status_id: Status[:published].id)
+      about.parts.create(name: 'body', content: 'About <r:title />')
+
+      get '/about'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('About About')
+    end
+
+    it 'renders a nested published page' do
+      section = FactoryBot.create(:page, title: 'Section', slug: 'section', parent: home, status_id: Status[:published].id)
+      article = FactoryBot.create(:page, title: 'Article', slug: 'article', parent: section, status_id: Status[:published].id)
+      article.parts.create(name: 'body', content: 'Deep content')
+
+      get '/section/article'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Deep content')
+    end
+  end
+
+  describe 'unknown paths' do
+    it 'renders the not-found template with a 404 status' do
+      get '/does/not/exist'
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include('could not be located')
+    end
+  end
+
+  describe 'content type' do
+    it 'sets the response Content-Type from the page layout' do
+      layout = Layout.create!(name: 'Plain', content: '<r:content />', content_type: 'text/plain')
+      page = FactoryBot.create(:page, title: 'Raw', slug: 'raw', parent: home, status_id: Status[:published].id, layout: layout)
+      page.parts.create(name: 'body', content: 'plain body')
+
+      get '/raw'
+      expect(response.media_type).to eq('text/plain')
+    end
+  end
+
+  describe '.cache_timeout' do
+    it 'round-trips through the response cache director' do
+      original = SiteController.cache_timeout
+      SiteController.cache_timeout = 5.minutes
+      expect(SiteController.cache_timeout).to eq(5.minutes)
+    ensure
+      SiteController.cache_timeout = original
+    end
+  end
+end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,184 @@
+require 'spec_helper'
+
+describe Page do
+  let(:home) { FactoryBot.create(:home, title: 'Home') }
+
+  describe 'paths' do
+    it 'renders the root path as "/"' do
+      expect(home.path).to eq('/')
+    end
+
+    it 'builds a child path from the parent path and slug' do
+      parent = FactoryBot.create(:page, title: 'Parent', slug: 'parent', parent: home, status_id: Status[:published].id)
+      expect(parent.path).to eq('/parent')
+    end
+
+    it 'builds a nested path across multiple ancestors' do
+      parent = FactoryBot.create(:page, title: 'Parent', slug: 'parent', parent: home, status_id: Status[:published].id)
+      child  = FactoryBot.create(:page, title: 'Child', slug: 'child', parent: parent, status_id: Status[:published].id)
+      expect(child.path).to eq('/parent/child')
+    end
+
+    it 'returns an empty string when the slug is blank' do
+      expect(FactoryBot.build(:page, slug: '').path).to eq('')
+    end
+
+    it '#child_path joins the page path with the child slug' do
+      parent = FactoryBot.create(:page, title: 'Parent', slug: 'parent', parent: home, status_id: Status[:published].id)
+      expect(home.child_path(parent)).to eq('/parent')
+    end
+
+    it 'aliases #url to #path' do
+      expect(home.url).to eq(home.path)
+    end
+  end
+
+  describe 'status' do
+    it '#status returns the Status for the status_id' do
+      expect(home.status).to eq(Status[:published])
+      expect(home.status.name).to eq('Published')
+    end
+
+    it '#status= assigns the status_id from a Status' do
+      page = FactoryBot.build(:page)
+      page.status = Status[:hidden]
+      expect(page.status_id).to eq(Status[:hidden].id)
+    end
+
+    it '#published? is true only for published pages' do
+      draft = FactoryBot.create(:page, title: 'Draft', slug: 'draft', parent: home, status_id: Status[:draft].id)
+      expect(home.published?).to be(true)
+      expect(draft.published?).to be(false)
+    end
+
+    it '#hidden? is true only for hidden pages' do
+      # Built (not created) to avoid the handle_hidden_status save callback,
+      # which references an unset config method in this environment.
+      hidden = FactoryBot.build(:page, title: 'Hidden', slug: 'hidden', parent: home, status_id: Status[:hidden].id)
+      expect(hidden.hidden?).to be(true)
+      expect(home.hidden?).to be(false)
+    end
+
+    it '#scheduled? is true only for scheduled pages' do
+      scheduled = FactoryBot.create(:page, title: 'Sched', slug: 'sched', parent: home, status_id: Status[:scheduled].id)
+      expect(scheduled.scheduled?).to be(true)
+      expect(home.scheduled?).to be(false)
+    end
+
+    it 'stamps published_at when a page is published' do
+      page = FactoryBot.create(:page, title: 'Pub', slug: 'pub', parent: home, status_id: Status[:published].id)
+      expect(page.published_at).to be_present
+    end
+
+    it 'does not stamp published_at for an unpublished page' do
+      draft = FactoryBot.create(:page, title: 'Draft2', slug: 'draft2', parent: home, status_id: Status[:draft].id)
+      expect(draft.published_at).to be_nil
+    end
+  end
+
+  describe 'parts' do
+    it '#part returns the named part' do
+      home.parts.create(name: 'body', content: 'x')
+      expect(home.part('body').content).to eq('x')
+    end
+
+    it '#part? reflects whether the part exists' do
+      home.parts.create(name: 'body', content: 'x')
+      expect(home.part?('body')).to be(true)
+      expect(home.part?('sidebar')).to be(false)
+    end
+
+    it '#inherits_part? is true when an ancestor has the part but the page does not' do
+      home.parts.create(name: 'body', content: 'x')
+      child = FactoryBot.create(:page, title: 'Child', slug: 'child', parent: home, status_id: Status[:published].id)
+      expect(child.part?('body')).to be(false)
+      expect(child.inherits_part?('body')).to be(true)
+    end
+
+    it '#has_or_inherits_part? covers both direct and inherited parts' do
+      home.parts.create(name: 'body', content: 'x')
+      child = FactoryBot.create(:page, title: 'Child', slug: 'child', parent: home, status_id: Status[:published].id)
+      expect(child.has_or_inherits_part?('body')).to be(true)
+      expect(child.has_or_inherits_part?('missing')).to be(false)
+    end
+  end
+
+  describe 'fields' do
+    it '#field looks up a field by name, case-insensitively' do
+      home.fields.create(name: 'Description', content: 'desc')
+      expect(home.field('description').content).to eq('desc')
+      expect(home.field(:Description).content).to eq('desc')
+    end
+
+    it '#field returns nil for an unknown field' do
+      expect(home.field('nope')).to be_nil
+    end
+  end
+
+  describe 'rendering' do
+    it '#render renders the body part when there is no layout' do
+      page = FactoryBot.create(:page, title: 'NoLayout', slug: 'nl', parent: home, status_id: Status[:published].id)
+      page.parts.create(name: 'body', content: 'Body: <r:title />')
+      expect(page.render).to eq('Body: NoLayout')
+    end
+
+    it '#render renders through the layout when one is present' do
+      layout = Layout.create!(name: 'Simple', content: 'Layout: <r:title />')
+      page = FactoryBot.create(:page, title: 'WithLayout', slug: 'wl', parent: home, status_id: Status[:published].id, layout: layout)
+      expect(page.render).to eq('Layout: WithLayout')
+    end
+
+    it '#render_part returns an empty string for a missing part' do
+      expect(home.render_part(:nonexistent)).to eq('')
+    end
+
+    it '#render_snippet parses the snippet content in the page context' do
+      snippet = FactoryBot.build(:snippet, name: 'greeting', content: 'Hello from <r:title />')
+      expect(home.render_snippet(snippet)).to eq('Hello from Home')
+    end
+  end
+
+  describe '.new_with_defaults' do
+    it 'builds a page with the configured default parts, fields, and status' do
+      page = Page.new_with_defaults
+      expect(page.parts.map(&:name)).to eq(%w[body extended])
+      expect(page.fields.map(&:name)).to eq(%w[Keywords Description])
+      expect(page.status).to eq(Status[:draft])
+    end
+  end
+
+  describe 'class helpers' do
+    it '.root returns the parentless page' do
+      home
+      expect(Page.root).to eq(home)
+    end
+
+    it '.date_column_names lists the date/time columns' do
+      expect(Page.date_column_names).to include('created_at', 'updated_at', 'published_at')
+    end
+
+    it '.descendant_class returns Page for blank/nil/"Page"' do
+      expect(Page.descendant_class(nil)).to eq(Page)
+      expect(Page.descendant_class('')).to eq(Page)
+      expect(Page.descendant_class('Page')).to eq(Page)
+    end
+
+    it '.descendant_class raises for an invalid class name' do
+      expect { Page.descendant_class('NotARealPage') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'response defaults' do
+    it '#cache? is true' do
+      expect(home.cache?).to be(true)
+    end
+
+    it '#response_code is 200' do
+      expect(home.response_code).to eq(200)
+    end
+
+    it '#headers is an empty hash' do
+      expect(home.headers).to eq({})
+    end
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+
+describe Site do
+  def create_site(attrs = {})
+    Site.create!({ name: 'Test', base_domain: 'test.local', domain: 'test\\.local' }.merge(attrs))
+  end
+
+  describe '#url' do
+    let(:site) { create_site(base_domain: 'example.com') }
+
+    it 'returns the site root for no path' do
+      expect(site.url).to eq('http://example.com/')
+    end
+
+    it 'joins a path onto the base domain' do
+      expect(site.url('/about')).to eq('http://example.com/about')
+    end
+  end
+
+  describe '.find_for_host' do
+    it 'returns the default site for a blank hostname' do
+      default = create_site(name: 'Default', base_domain: 'localhost', domain: '')
+      expect(Site.find_for_host('')).to eq(default)
+    end
+
+    it 'matches a site by its base_domain' do
+      # No empty-domain site here: an empty domain pattern matches every host
+      # (Regexp.compile('') matches anything) and would shadow specific sites.
+      blog = create_site(name: 'Blog', base_domain: 'blog.example.com', domain: 'blog\\.example\\.com')
+      expect(Site.find_for_host('blog.example.com')).to eq(blog)
+    end
+
+    it 'falls back to the default site for an unknown host' do
+      default = create_site(name: 'Default', base_domain: 'localhost', domain: '')
+      expect(Site.find_for_host('unknown.example.com')).to eq(default)
+    end
+  end
+
+  describe '.default' do
+    it 'returns the site whose domain is empty' do
+      default = create_site(name: 'Default', base_domain: 'localhost', domain: '')
+      expect(Site.default).to eq(default)
+    end
+  end
+
+  describe '.catchall' do
+    it 'creates a workable default site when none exists' do
+      site = Site.catchall
+      expect(site).to be_persisted
+      expect(site.name).to eq('default_site')
+      expect(site.base_domain).to eq('localhost')
+    end
+  end
+
+  describe '.several?' do
+    before { Site.several = nil }
+
+    it 'is false with a single site' do
+      create_site
+      expect(Site.several?).to be(false)
+    end
+
+    it 'is true with more than one site' do
+      create_site(name: 'One', base_domain: 'one.local', domain: 'one\\.local')
+      create_site(name: 'Two', base_domain: 'two.local', domain: 'two\\.local')
+      expect(Site.several?).to be(true)
+    end
+  end
+
+  describe 'validations' do
+    it 'requires a name and base_domain' do
+      site = Site.new
+      site.valid?
+      expect(site.errors[:name]).to be_present
+      expect(site.errors[:base_domain]).to be_present
+    end
+
+    it 'requires a unique domain' do
+      create_site(domain: 'dup\\.local')
+      dup = Site.new(name: 'Dup', base_domain: 'dup2.local', domain: 'dup\\.local')
+      expect(dup).not_to be_valid
+      expect(dup.errors[:domain]).to be_present
+    end
+  end
+
+  describe 'homepage creation' do
+    it 'builds a homepage automatically after create' do
+      site = create_site(base_domain: 'hp.local', domain: 'hp\\.local')
+      expect(site.homepage).to be_present
+      expect(site.homepage.breadcrumb).to eq('Home')
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds comprehensive RSpec model and controller specs for the core `Site`, `Page`, and `SiteController` components. These tests cover expected behaviors, edge cases, and validation logic, significantly improving test coverage and reliability.

**New RSpec test coverage:**

*Controller specs:*
- Adds request specs for `SiteController` covering page rendering, nested routes, not-found handling, content type headers, and cache timeout configuration.

*Model specs:*
- Adds model specs for `Page`, testing path generation, status logic, part and field access, rendering, class helpers, and response defaults.
- Adds model specs for `Site`, testing URL generation, host matching, default/catchall site logic, site count checks, validations, and automatic homepage creation.