### PR TITLE
Models Specs

### DIFF
--- a/spec/models/admins_site_spec.rb
+++ b/spec/models/admins_site_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe AdminsSite do
+  it 'uses the admins_sites table' do
+    expect(AdminsSite.table_name).to eq('admins_sites')
+  end
+
+  describe 'associations' do
+    it 'belongs to an admin that is a User' do
+      association = AdminsSite.reflect_on_association(:admin)
+      expect(association.macro).to eq(:belongs_to)
+      expect(association.options[:class_name]).to eq('User')
+    end
+
+    it 'belongs to a site' do
+      expect(AdminsSite.reflect_on_association(:site).macro).to eq(:belongs_to)
+    end
+  end
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -259,4 +259,191 @@ RSpec.describe Asset, type: :model do
       expect(asset.public_url('normal')).to eq('https://s3.amazonaws.com/bucket/randomlegacykey')
     end
   end
+
+  # Shared helpers for the blocks below.
+  def register_image_and_other_types
+    AssetType.new(:image, styles: :standard, extensions: %w[png], mime_types: %w[image/png]) unless AssetType.known?(:image)
+    AssetType.new(:other, icon: 'unknown') unless AssetType.known?(:other)
+  end
+
+  def png_bytes
+    Base64.decode64('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==')
+  end
+
+  def attach_png(filename: 'pixel.png', **attrs)
+    io = StringIO.new(png_bytes)
+    io.set_encoding(Encoding::BINARY)
+    described_class.new(attrs).tap do |asset|
+      asset.asset.attach(io: io, filename: filename, content_type: 'image/png')
+      asset.save!
+    end
+  end
+
+  describe 'unattached accessors' do
+    it 'falls back to the stored columns when nothing is attached' do
+      asset = described_class.new(asset_file_name: 'legacy.PNG', asset_content_type: 'image/png', asset_file_size: 42)
+
+      expect(asset.filename).to eq('legacy.PNG')
+      expect(asset.content_type).to eq('image/png')
+      expect(asset.byte_size).to eq(42)
+    end
+
+    it 'derives basename and extension from the stored filename' do
+      asset = described_class.new(asset_file_name: 'legacy.PNG')
+
+      expect(asset.basename).to eq('legacy')
+      expect(asset.original_extension).to eq('png')
+      expect(asset.extension('original')).to eq('png')
+    end
+
+    it 'returns the original extension for a style with no defined format' do
+      asset = described_class.new(asset_file_name: 'legacy.png')
+
+      expect(asset.extension('no_such_style')).to eq('png')
+    end
+  end
+
+  describe 'geometry' do
+    before { register_image_and_other_types }
+
+    it 'reports width, height and aspect from the original dimensions' do
+      asset = described_class.new(original_width: 100, original_height: 50)
+
+      expect(asset.width).to eq(100)
+      expect(asset.height).to eq(50)
+      expect(asset.aspect).to eq(2.0)
+      expect(asset.dimensions_known?).to be(true)
+    end
+
+    it 'reports a horizontal orientation for a wide asset' do
+      asset = described_class.new(original_width: 100, original_height: 50)
+
+      expect(asset.orientation).to eq('horizontal')
+      expect(asset.horizontal?).to be(true)
+      expect(asset.vertical?).to be(false)
+      expect(asset.square?).to be(false)
+    end
+
+    it 'reports a vertical orientation for a tall asset' do
+      asset = described_class.new(original_width: 50, original_height: 100)
+
+      expect(asset.orientation).to eq('vertical')
+      expect(asset.vertical?).to be(true)
+    end
+
+    it 'reports a square orientation for an equal-sided asset' do
+      asset = described_class.new(original_width: 100, original_height: 100)
+
+      expect(asset.orientation).to eq('square')
+      expect(asset.square?).to be(true)
+    end
+
+    it 'is not dimensions_known? without stored dimensions' do
+      expect(described_class.new.dimensions_known?).to be(false)
+    end
+
+    it 'raises a StyleError for a style that is not defined' do
+      asset = described_class.new(original_width: 100, original_height: 50)
+
+      expect { asset.geometry('no_such_style') }.to raise_error(TrustyCms::StyleError)
+    end
+  end
+
+  describe '#active_storage_transformations' do
+    subject(:asset) { described_class.new }
+
+    it 'resizes to fill for cropping modifiers' do
+      expect(asset.send(:active_storage_transformations, '100x80#')).to eq(resize_to_fill: [100, 80])
+    end
+
+    it 'resizes to limit for the shrink modifier' do
+      expect(asset.send(:active_storage_transformations, '100x80>')).to eq(resize_to_limit: [100, 80])
+    end
+
+    it 'resizes to limit when there is no modifier' do
+      expect(asset.send(:active_storage_transformations, '100x80')).to eq(resize_to_limit: [100, 80])
+    end
+
+    it 'returns no transformations for a blank geometry' do
+      expect(asset.send(:active_storage_transformations, '')).to eq({})
+    end
+  end
+
+  describe 'scopes' do
+    before { register_image_and_other_types }
+
+    let!(:image) { attach_png(caption: 'a picture', title: 'Pixel') }
+
+    describe '.latest' do
+      it 'includes recently created assets up to the limit' do
+        expect(described_class.latest(5)).to include(image)
+      end
+    end
+
+    describe '.of_types' do
+      it 'includes assets whose blob content type matches the given types' do
+        expect(described_class.of_types([:image])).to include(image)
+      end
+
+      it 'returns none when the given types have no mime types' do
+        expect(described_class.of_types([:no_such_type])).to be_empty
+      end
+    end
+
+    describe '.matching' do
+      it 'matches on filename, title or caption, case-insensitively' do
+        expect(described_class.matching('PIXEL')).to include(image)
+        expect(described_class.matching('picture')).to include(image)
+      end
+    end
+
+    describe '.excepting' do
+      it 'excludes the given asset ids' do
+        expect(described_class.excepting([image.id]).to_sql).to match(/NOT IN/)
+        expect(described_class.excepting([image.id])).not_to include(image)
+      end
+
+      it 'adds no exclusion when given an empty list' do
+        expect(described_class.excepting([])).to eq({})
+      end
+    end
+  end
+
+  describe '#attached_to?' do
+    before { register_image_and_other_types }
+
+    it 'is true for a page the asset is attached to, false otherwise' do
+      asset = attach_png
+      page = FactoryBot.create(:page, title: 'Attached')
+      other_page = FactoryBot.create(:page, title: 'Unattached')
+      asset.pages << page
+
+      expect(asset.attached_to?(page)).to be(true)
+      expect(asset.attached_to?(other_page)).to be(false)
+    end
+  end
+
+  describe 'class helpers' do
+    before { register_image_and_other_types }
+
+    it 'exposes the known asset type names' do
+      expect(described_class.known_types).to eq(AssetType.known_types)
+    end
+
+    it 'lists ransackable attributes' do
+      expect(described_class.ransackable_attributes).to include('title', 'caption', 'uuid')
+    end
+
+    it 'exposes the image thumbnail sizes and names' do
+      expect(described_class.thumbnail_sizes).to eq(AssetType.find(:image).active_storage_styles)
+      expect(described_class.thumbnail_names).to eq(described_class.thumbnail_sizes.keys)
+    end
+
+    # NOTE: .thumbnail_options is currently broken for the standard hash-style
+    # styles — it does `description << v` where v is the style Hash, which
+    # raises TypeError. Documenting the bug here rather than asserting success.
+    it 'raises when building thumbnail options from hash-style styles (known bug)' do
+      expect { described_class.thumbnail_options }.to raise_error(TypeError)
+    end
+  end
 end

--- a/spec/models/asset_type_spec.rb
+++ b/spec/models/asset_type_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe AssetType do
+  # AssetType keeps its registry in class variables, so registrations persist
+  # for the whole suite. Register uniquely-named types (guarded by .known?) so
+  # these examples don't depend on what other specs have registered.
+  before(:all) do
+    AssetType.new(:other, icon: 'unknown') unless AssetType.known?(:other)
+    unless AssetType.known?(:spec_image)
+      AssetType.new(:spec_image,
+                    icon: 'image',
+                    styles: :standard,
+                    extensions: %w[spx],
+                    mime_types: %w[image/spectest])
+    end
+  end
+
+  let(:image) { AssetType.find(:spec_image) }
+
+  describe '#plural' do
+    it 'pluralizes the name' do
+      expect(image.plural).to eq('spec_images')
+    end
+  end
+
+  describe '#mime_types' do
+    it 'returns the configured mime types' do
+      expect(image.mime_types).to eq(%w[image/spectest])
+    end
+  end
+
+  describe '#condition' do
+    it 'builds an IN clause over its mime types' do
+      sql, *values = image.condition
+      expect(sql).to match(/asset_content_type IN/)
+      expect(values).to eq(%w[image/spectest])
+    end
+  end
+
+  describe '#non_condition' do
+    it 'builds a NOT IN clause over its mime types' do
+      sql, *values = image.non_condition
+      expect(sql).to match(/NOT asset_content_type IN/)
+      expect(values).to eq(%w[image/spectest])
+    end
+  end
+
+  describe '#standard_styles' do
+    it 'defines icon, thumbnail and original styles' do
+      expect(image.standard_styles.keys).to match_array(%i[icon thumbnail original])
+    end
+  end
+
+  describe '#normalize_style_rules' do
+    it 'wraps a bare geometry string in a hash' do
+      expect(image.normalize_style_rules(small: '100x100')).to eq(small: { geometry: '100x100' })
+    end
+
+    it 'parses a key=value rule string into a hash' do
+      result = image.normalize_style_rules(big: 'geometry=640x640,format=jpg')
+      expect(result[:big]).to eq(geometry: '640x640', format: 'jpg')
+    end
+  end
+
+  describe '.known?' do
+    it 'is true for a registered type' do
+      expect(AssetType.known?(:spec_image)).to be(true)
+    end
+
+    it 'is false for an unregistered type' do
+      expect(AssetType.known?(:nonexistent)).to be(false)
+    end
+  end
+
+  describe '.find and .[]' do
+    it 'looks up a type by name' do
+      expect(AssetType.find(:spec_image)).to eq(image)
+    end
+
+    it 'aliases .[] to .find' do
+      expect(AssetType[:spec_image]).to eq(image)
+    end
+
+    it 'returns nil for an unknown type' do
+      expect(AssetType.find(:nonexistent)).to be_nil
+    end
+  end
+
+  describe '.from_extension' do
+    it 'finds a type by a registered extension' do
+      expect(AssetType.from_extension('spx')).to eq(image)
+    end
+  end
+
+  describe '.from_mimetype' do
+    it 'finds a type by a registered mime type' do
+      expect(AssetType.from_mimetype('image/spectest')).to eq(image)
+    end
+  end
+
+  describe '.for' do
+    it 'returns the catchall type when there is no attachment' do
+      expect(AssetType.for(nil)).to eq(AssetType.catchall)
+    end
+  end
+
+  describe '.catchall' do
+    it 'is the :other type' do
+      expect(AssetType.catchall).to eq(AssetType.find(:other))
+    end
+  end
+
+  describe '.all and .known_types' do
+    it 'includes registered types' do
+      expect(AssetType.known_types).to include(:spec_image)
+      expect(AssetType.all).to include(image)
+    end
+  end
+
+  describe '.known_mimetypes' do
+    it 'includes registered mime types' do
+      expect(AssetType.known_mimetypes).to include('image/spectest')
+    end
+  end
+
+  describe '.mime_types_for' do
+    it 'returns the mime types for the named types' do
+      expect(AssetType.mime_types_for(:spec_image)).to eq(%w[image/spectest])
+    end
+  end
+
+  describe '.slice' do
+    it 'returns the named types' do
+      expect(AssetType.slice(:spec_image)).to eq([image])
+    end
+  end
+end

--- a/spec/models/file_not_found_page_spec.rb
+++ b/spec/models/file_not_found_page_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe FileNotFoundPage do
+  subject(:page) { FileNotFoundPage.new }
+
+  it 'is a Page' do
+    expect(page).to be_a(Page)
+  end
+
+  describe '#cache_timeout' do
+    it 'is five minutes' do
+      expect(page.cache_timeout).to eq(5.minutes)
+    end
+  end
+
+  describe '#allowed_children' do
+    it 'has none' do
+      expect(page.allowed_children).to eq([])
+    end
+  end
+
+  describe '#virtual?' do
+    it 'is true' do
+      expect(page.virtual?).to be(true)
+    end
+  end
+
+  describe '#response_code' do
+    it 'is 404' do
+      expect(page.response_code).to eq(404)
+    end
+  end
+end

--- a/spec/models/haml_filter_spec.rb
+++ b/spec/models/haml_filter_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe HamlFilter do
+  subject(:filter) { HamlFilter.new }
+
+  it 'is a TextFilter' do
+    expect(filter).to be_a(TextFilter)
+  end
+
+  describe '.filter_name' do
+    it 'is derived from the class name' do
+      expect(HamlFilter.filter_name).to eq('Haml')
+    end
+  end
+
+  describe '#filter' do
+    it 'renders Haml markup to HTML' do
+      expect(filter.filter('%p Hello world')).to eq("<p>Hello world</p>\n")
+    end
+
+    it 'un-escapes radius tags that Haml would otherwise escape' do
+      # Haml escapes the `=` output to &lt;r:title /&gt;; the filter restores it.
+      expect(filter.filter('= "<r:title />"')).to eq("<r:title/>\n")
+    end
+
+    it 'leaves radius tags in plain text intact' do
+      expect(filter.filter("%p\n  <r:title />")).to eq("<p>\n<r:title />\n</p>\n")
+    end
+  end
+end

--- a/spec/models/menu_renderer_spec.rb
+++ b/spec/models/menu_renderer_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe MenuRenderer do
+  # MenuRenderer is extended onto a Page instance (see Admin::NodeHelper).
+  let(:page) { Page.new.tap { |p| p.extend(MenuRenderer) } }
+
+  # MenuRenderer keeps its exclusion list in a module-level ivar. Isolate it so
+  # the .exclude example doesn't leak into others regardless of run order.
+  before(:all) { @orig_excluded = MenuRenderer.instance_variable_get(:@excluded_class_names) }
+  after(:all)  { MenuRenderer.instance_variable_set(:@excluded_class_names, @orig_excluded) }
+  before       { MenuRenderer.instance_variable_set(:@excluded_class_names, []) }
+
+  describe '#view' do
+    it 'reads back an assigned view' do
+      view = Object.new
+      page.view = view
+      expect(page.view).to eq(view)
+    end
+  end
+
+  describe '#menu_renderer_module_name' do
+    it 'is MenuRenderer for a plain page' do
+      expect(page.menu_renderer_module_name).to eq('MenuRenderer')
+    end
+  end
+
+  describe '#additional_menu_features?' do
+    it 'is false when no page-specific renderer module exists' do
+      expect(page.additional_menu_features?).to be_falsey
+    end
+  end
+
+  describe '#allowed_child_classes' do
+    it 'constantizes the names from the allowed-children cache' do
+      page.allowed_children_cache = 'Page,FileNotFoundPage'
+      expect(page.allowed_child_classes).to eq([Page, FileNotFoundPage])
+    end
+
+    it 'skips names that cannot be constantized' do
+      page.allowed_children_cache = 'Page,NotARealClassName'
+      expect(page.allowed_child_classes).to eq([Page])
+    end
+
+    it 'excludes names registered via .exclude' do
+      MenuRenderer.exclude('FileNotFoundPage')
+      page.allowed_children_cache = 'Page,FileNotFoundPage'
+      expect(page.allowed_child_classes).to eq([Page])
+      expect(MenuRenderer.excluded_class_names).to include('FileNotFoundPage')
+    end
+  end
+
+  describe '#add_child_disabled?' do
+    it 'is true when there are no allowed child classes' do
+      page.allowed_children_cache = ''
+      expect(page.add_child_disabled?).to be(true)
+    end
+
+    it 'is false when there is at least one allowed child class' do
+      page.allowed_children_cache = 'Page'
+      expect(page.add_child_disabled?).to be(false)
+    end
+  end
+end

--- a/spec/models/page_attachment_spec.rb
+++ b/spec/models/page_attachment_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe PageAttachment do
+  describe '#selected?' do
+    it 'is false by default' do
+      expect(PageAttachment.new.selected?).to be(false)
+    end
+
+    it 'is true when selected is set to a truthy value' do
+      attachment = PageAttachment.new
+      attachment.selected = '1'
+      expect(attachment.selected?).to be(true)
+    end
+
+    it 'is false when selected is set to nil' do
+      attachment = PageAttachment.new
+      attachment.selected = nil
+      expect(attachment.selected?).to be(false)
+    end
+  end
+
+  describe '#add_to_list_bottom' do
+    it 'keeps an already-assigned position' do
+      attachment = PageAttachment.new(position: 5)
+      attachment.add_to_list_bottom
+      expect(attachment.position).to eq(5)
+    end
+  end
+end

--- a/spec/models/page_context_spec.rb
+++ b/spec/models/page_context_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe PageContext do
+  let(:page) { FactoryBot.build(:page, title: 'My Page') }
+  let(:context) { PageContext.new(page) }
+
+  describe '#initialize' do
+    it 'exposes the page it was built for' do
+      expect(context.page).to eq(page)
+    end
+
+    it 'registers the page as a global' do
+      expect(context.globals.page).to eq(page)
+    end
+
+    it 'defines a tag for each of the page tags' do
+      expect(context.definitions.keys).to include('title')
+    end
+  end
+
+  describe '#dup' do
+    it 'returns an independent PageContext for the same page' do
+      copy = context.dup
+      expect(copy).to be_a(PageContext)
+      expect(copy).not_to equal(context)
+      expect(copy.page).to eq(page)
+      expect(copy.globals.page).to eq(page)
+    end
+
+    it 'copies the definitions rather than sharing them' do
+      copy = context.dup
+      expect(copy.definitions).not_to equal(context.definitions)
+      expect(copy.definitions.keys).to eq(context.definitions.keys)
+    end
+  end
+
+  describe 'rendering through Page#parse' do
+    it 'renders a standard tag' do
+      expect(page.send(:parse, '<r:title />')).to eq('My Page')
+    end
+
+    context 'when a tag raises and errors are suppressed (production-like)' do
+      before { allow_any_instance_of(PageContext).to receive(:raise_errors?).and_return(false) }
+
+      it 'renders the error message inside a div' do
+        output = page.send(:parse, '<r:find />')
+        expect(output).to match(%r{<div><strong>.*find.*</strong></div>})
+      end
+    end
+
+    context 'when errors are raised (development/test)' do
+      it 'propagates the exception' do
+        expect { page.send(:parse, '<r:find />') }.to raise_error(StandardTags::TagError)
+      end
+    end
+  end
+end

--- a/spec/models/page_field_spec.rb
+++ b/spec/models/page_field_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe PageField do
+  describe 'validations' do
+    it 'requires a name' do
+      field = PageField.new(content: 'value')
+      expect(field).not_to be_valid
+      expect(field.errors[:name]).to be_present
+    end
+
+    it 'is valid with a name' do
+      expect(PageField.new(name: 'keywords', content: 'value')).to be_valid
+    end
+  end
+end

--- a/spec/models/page_part_spec.rb
+++ b/spec/models/page_part_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe PagePart do
+  describe 'validations' do
+    it 'requires a name' do
+      part = PagePart.new(content: 'body content')
+      expect(part).not_to be_valid
+      expect(part.errors[:name]).to be_present
+    end
+
+    it 'rejects a name longer than 100 characters' do
+      part = PagePart.new(name: 'a' * 101)
+      expect(part).not_to be_valid
+      expect(part.errors[:name]).to be_present
+    end
+
+    it 'rejects a filter_id longer than 25 characters' do
+      part = PagePart.new(name: 'body', filter_id: 'a' * 26)
+      expect(part).not_to be_valid
+      expect(part.errors[:filter_id]).to be_present
+    end
+
+    it 'is valid with a name' do
+      expect(PagePart.new(name: 'body')).to be_valid
+    end
+  end
+
+  describe 'ordering' do
+    it 'orders by name via the default scope' do
+      expect(PagePart.all.to_sql).to match(/ORDER BY name/i)
+    end
+  end
+end

--- a/spec/models/rails_page_spec.rb
+++ b/spec/models/rails_page_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe RailsPage do
+  subject(:page) { RailsPage.new }
+
+  it 'is a Page' do
+    expect(page).to be_a(Page)
+  end
+
+  describe '#url' do
+    it 'returns an explicitly assigned url' do
+      page.url = '/custom/path'
+      expect(page.url).to eq('/custom/path')
+    end
+  end
+
+  describe '#build_parts_from_hash!' do
+    it 'creates page parts from a content hash' do
+      page.build_parts_from_hash!('body' => 'Hello', 'sidebar' => 'World')
+      expect(page.part('body').content).to eq('Hello')
+      expect(page.part('sidebar').content).to eq('World')
+    end
+
+    it 'updates the content of an existing part' do
+      page.build_parts_from_hash!('body' => 'first')
+      page.build_parts_from_hash!('body' => 'second')
+      bodies = page.parts.select { |p| p.name == 'body' }
+      expect(bodies.size).to eq(1)
+      expect(bodies.first.content).to eq('second')
+    end
+  end
+end

--- a/spec/models/snippet_finder_spec.rb
+++ b/spec/models/snippet_finder_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe SnippetFinder do
+  describe '.finder_types' do
+    it 'looks in Snippet' do
+      expect(SnippetFinder.finder_types).to eq([Snippet])
+    end
+  end
+
+  describe '.find' do
+    it 'finds a snippet by id' do
+      snippet = FactoryBot.create(:snippet)
+      expect(SnippetFinder.find(snippet.id)).to eq(snippet)
+    end
+  end
+
+  describe '.find_by_name' do
+    it 'finds a snippet by name' do
+      snippet = FactoryBot.create(:snippet, name: 'sidebar')
+      expect(SnippetFinder.find_by_name('sidebar')).to eq(snippet)
+    end
+
+    it 'returns nil when no snippet matches' do
+      expect(SnippetFinder.find_by_name('does_not_exist')).to be_nil
+    end
+  end
+end

--- a/spec/models/snippet_tags_spec.rb
+++ b/spec/models/snippet_tags_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe SnippetTags do
+  # In production the snippets extension mixes SnippetTags into Page. Mirror
+  # that here so the snippet/yield tags are available through Page#parse.
+  before(:all) { Page.include(SnippetTags) unless Page.include?(SnippetTags) }
+
+  let(:page) { Page.new(title: 'Host') }
+
+  def render(input)
+    page.send(:parse, input)
+  end
+
+  describe '<r:snippet>' do
+    it 'renders the named snippet within the page' do
+      FactoryBot.create(:snippet, name: 'hello', content: 'Hello Snippet')
+      expect(render('<r:snippet name="hello" />')).to eq('Hello Snippet')
+    end
+
+    it 'substitutes the double-tag body for <r:yield/>' do
+      FactoryBot.create(:snippet, name: 'wrap', content: 'before <r:yield/> after')
+      expect(render('<r:snippet name="wrap">MIDDLE</r:snippet>')).to eq('before MIDDLE after')
+    end
+
+    it 'raises when the name attribute is missing' do
+      expect { render('<r:snippet />') }.to raise_error(StandardTags::TagError, /name.*attribute/)
+    end
+
+    it 'raises when the snippet does not exist' do
+      expect { render('<r:snippet name="nope" />') }
+        .to raise_error(SnippetTags::TagError, /snippet 'nope' not found/)
+    end
+
+    it 'caches a snippet looked up more than once in a render' do
+      FactoryBot.create(:snippet, name: 'twice', content: 'X')
+      expect(SnippetFinder).to receive(:find_by_name).once.and_call_original
+      render('<r:snippet name="twice" /><r:snippet name="twice" />')
+    end
+  end
+
+  describe '<r:yield>' do
+    it 'outputs nothing outside of a double-tag snippet' do
+      expect(render('<r:yield/>')).to eq('')
+    end
+  end
+end

--- a/spec/models/snippet_tags_spec.rb
+++ b/spec/models/snippet_tags_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 describe SnippetTags do
-  # In production the snippets extension mixes SnippetTags into Page. Mirror
-  # that here so the snippet/yield tags are available through Page#parse.
-  before(:all) { Page.include(SnippetTags) unless Page.include?(SnippetTags) }
-
-  let(:page) { Page.new(title: 'Host') }
+  # In production the snippets extension mixes SnippetTags in. Extend a single
+  # page instance (as MenuRenderer is used) so the snippet/yield tags are
+  # available through Page#parse without mutating the global Page class.
+  let(:page) { Page.new(title: 'Host').tap { |p| p.extend(SnippetTags) } }
 
   def render(input)
     page.send(:parse, input)

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Status do
+  describe '#initialize' do
+    it 'assigns id and name from options' do
+      status = Status.new(id: 1, name: 'Draft')
+      expect(status.id).to eq(1)
+      expect(status.name).to eq('Draft')
+    end
+
+    it 'accepts string keys' do
+      status = Status.new('id' => 1, 'name' => 'Draft')
+      expect(status.id).to eq(1)
+      expect(status.name).to eq('Draft')
+    end
+  end
+
+  describe '#symbol' do
+    it 'returns the downcased name as a symbol' do
+      expect(Status.new(name: 'Published').symbol).to eq(:published)
+    end
+  end
+
+  describe '.[]' do
+    it 'finds a status by its symbol' do
+      expect(Status[:published].name).to eq('Published')
+    end
+
+    it 'is case-insensitive' do
+      expect(Status['Published']).to eq(Status[:published])
+    end
+
+    it 'returns nil for an unknown symbol' do
+      expect(Status[:nonexistent]).to be_nil
+    end
+  end
+
+  describe '.find' do
+    it 'finds a status by its id' do
+      expect(Status.find(100).name).to eq('Published')
+    end
+
+    it 'matches ids regardless of type' do
+      expect(Status.find('100')).to eq(Status.find(100))
+    end
+
+    it 'returns nil for an unknown id' do
+      expect(Status.find(999)).to be_nil
+    end
+  end
+
+  describe '.selectable' do
+    it 'returns all defined statuses' do
+      expect(Status.selectable.map(&:name)).to eq(%w[Draft Reviewed Scheduled Published Hidden])
+    end
+  end
+
+  describe '.selectable_values' do
+    it 'returns the names of all selectable statuses' do
+      expect(Status.selectable_values).to eq(%w[Draft Reviewed Scheduled Published Hidden])
+    end
+  end
+end

--- a/spec/models/text_filter_spec.rb
+++ b/spec/models/text_filter_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+# Defined at load time so TextFilter.inherited fires and registers a descendant.
+class SpecSampleFilter < TextFilter
+  def filter(text)
+    "[#{text}]"
+  end
+end
+
+describe TextFilter do
+  describe '#filter' do
+    it 'returns the text unchanged for the base filter' do
+      expect(TextFilter.new.filter('hello')).to eq('hello')
+    end
+  end
+
+  describe '.filter' do
+    it 'delegates to the singleton instance' do
+      expect(TextFilter.filter('hello')).to eq('hello')
+      expect(SpecSampleFilter.filter('hello')).to eq('[hello]')
+    end
+  end
+
+  describe '.inherited' do
+    it 'derives a filter_name from the subclass name' do
+      expect(SpecSampleFilter.filter_name).to eq('Spec Sample')
+    end
+  end
+
+  describe '.descendants_names' do
+    it 'includes the names of registered descendants, sorted' do
+      names = TextFilter.descendants_names
+      expect(names).to include('Spec Sample')
+      expect(names).to eq(names.sort)
+    end
+  end
+
+  describe '.find_descendant' do
+    it 'finds a descendant by its filter_name' do
+      expect(TextFilter.find_descendant('Spec Sample')).to eq(SpecSampleFilter)
+    end
+
+    it 'returns nil when no descendant matches' do
+      expect(TextFilter.find_descendant('No Such Filter')).to be_nil
+    end
+  end
+end

--- a/spec/models/trusty_cms/config_spec.rb
+++ b/spec/models/trusty_cms/config_spec.rb
@@ -1,49 +1,55 @@
 require 'spec_helper'
 
 describe TrustyCms::Config do
-  # The config table is excluded from DatabaseCleaner truncation, so these
-  # examples only exercise unsaved instances to avoid leaking rows.
+  # The custom #value= setter calls save!, and the config table is exempt from
+  # DatabaseCleaner truncation, so a saved row would leak across examples and
+  # collide on the unique key index. Build unsaved instances and assign the raw
+  # attribute with self[:value]= (write_attribute) to bypass the setter.
+  def config(key, value = nil)
+    TrustyCms::Config.new(key: key).tap do |c|
+      c[:value] = value unless value.nil?
+    end
+  end
 
   describe '#boolean?' do
     it 'is true when the key ends with a question mark' do
-      expect(TrustyCms::Config.new(key: 'feature.enabled?').boolean?).to be(true)
+      expect(config('feature.enabled?').boolean?).to be(true)
     end
 
     it 'is false for an ordinary key with no definition' do
-      expect(TrustyCms::Config.new(key: 'feature.name').boolean?).to be(false)
+      expect(config('feature.name').boolean?).to be(false)
     end
   end
 
   describe '#checked?' do
     it 'is true for a boolean setting whose value is "true"' do
-      expect(TrustyCms::Config.new(key: 'x?', value: 'true').checked?).to be(true)
+      expect(config('x?', 'true').checked?).to be(true)
     end
 
     it 'is false for a boolean setting whose value is not "true"' do
-      expect(TrustyCms::Config.new(key: 'x?', value: 'false').checked?).to be(false)
+      expect(config('x?', 'false').checked?).to be(false)
     end
   end
 
   describe '#value' do
     it 'returns a boolean for a boolean setting' do
-      expect(TrustyCms::Config.new(key: 'x?', value: 'true').value).to be(true)
+      expect(config('x?', 'true').value).to be(true)
     end
 
     it 'returns the raw string for a non-boolean setting' do
-      expect(TrustyCms::Config.new(key: 'plain', value: 'hello').value).to eq('hello')
+      expect(config('plain', 'hello').value).to eq('hello')
     end
   end
 
   describe '#selector?' do
     it 'is false when the definition does not restrict the value' do
-      expect(TrustyCms::Config.new(key: 'plain').selector?).to be(false)
+      expect(config('plain').selector?).to be(false)
     end
   end
 
   describe '#definition' do
     it 'returns a Definition even when none was declared' do
-      expect(TrustyCms::Config.new(key: 'undeclared').definition)
-        .to be_a(TrustyCms::Config::Definition)
+      expect(config('undeclared').definition).to be_a(TrustyCms::Config::Definition)
     end
   end
 

--- a/spec/models/trusty_cms/config_spec.rb
+++ b/spec/models/trusty_cms/config_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe TrustyCms::Config do
+  # The config table is excluded from DatabaseCleaner truncation, so these
+  # examples only exercise unsaved instances to avoid leaking rows.
+
+  describe '#boolean?' do
+    it 'is true when the key ends with a question mark' do
+      expect(TrustyCms::Config.new(key: 'feature.enabled?').boolean?).to be(true)
+    end
+
+    it 'is false for an ordinary key with no definition' do
+      expect(TrustyCms::Config.new(key: 'feature.name').boolean?).to be(false)
+    end
+  end
+
+  describe '#checked?' do
+    it 'is true for a boolean setting whose value is "true"' do
+      expect(TrustyCms::Config.new(key: 'x?', value: 'true').checked?).to be(true)
+    end
+
+    it 'is false for a boolean setting whose value is not "true"' do
+      expect(TrustyCms::Config.new(key: 'x?', value: 'false').checked?).to be(false)
+    end
+  end
+
+  describe '#value' do
+    it 'returns a boolean for a boolean setting' do
+      expect(TrustyCms::Config.new(key: 'x?', value: 'true').value).to be(true)
+    end
+
+    it 'returns the raw string for a non-boolean setting' do
+      expect(TrustyCms::Config.new(key: 'plain', value: 'hello').value).to eq('hello')
+    end
+  end
+
+  describe '#selector?' do
+    it 'is false when the definition does not restrict the value' do
+      expect(TrustyCms::Config.new(key: 'plain').selector?).to be(false)
+    end
+  end
+
+  describe '#definition' do
+    it 'returns a Definition even when none was declared' do
+      expect(TrustyCms::Config.new(key: 'undeclared').definition)
+        .to be_a(TrustyCms::Config::Definition)
+    end
+  end
+
+  describe '.site_settings' do
+    it 'lists the site-level settings' do
+      expect(TrustyCms::Config.site_settings).to eq(%w[site.title site.host local.timezone])
+    end
+  end
+
+  describe '.default_settings' do
+    it 'lists the default settings' do
+      expect(TrustyCms::Config.default_settings).to eq(
+        %w[defaults.locale defaults.page.filter defaults.page.parts defaults.page.fields defaults.page.status]
+      )
+    end
+  end
+end

--- a/spec/models/trusty_cms/page_response_cache_director_spec.rb
+++ b/spec/models/trusty_cms/page_response_cache_director_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe TrustyCms::PageResponseCacheDirector do
+  let(:listener) { double('listener') }
+
+  subject(:director) { described_class.new(page, listener) }
+
+  describe '.cache_timeout' do
+    around do |example|
+      original = described_class.cache_timeout
+      example.run
+      described_class.cache_timeout = original
+    end
+
+    it 'defaults to five minutes' do
+      described_class.instance_variable_set(:@cache_timeout, nil)
+      expect(described_class.cache_timeout).to eq(5.minutes)
+    end
+
+    it 'can be overridden' do
+      described_class.cache_timeout = 10.minutes
+      expect(described_class.cache_timeout).to eq(10.minutes)
+    end
+  end
+
+  describe '#set_cache_control' do
+    context 'when the request and page are both cacheable' do
+      before { allow(listener).to receive(:cacheable_request?).and_return(true) }
+
+      context 'and the page defines its own cache_timeout' do
+        let(:page) { double('page', cache?: true, cache_timeout: 2.minutes) }
+
+        it 'sets a public expiry using the page timeout' do
+          expect(listener).to receive(:set_expiry).with(2.minutes, public: true, private: false)
+          director.set_cache_control
+        end
+      end
+
+      context 'and the page has no cache_timeout' do
+        let(:page) { double('page', cache?: true) }
+
+        it 'sets a public expiry using the class timeout' do
+          allow(described_class).to receive(:cache_timeout).and_return(5.minutes)
+          expect(listener).to receive(:set_expiry).with(5.minutes, public: true, private: false)
+          director.set_cache_control
+        end
+      end
+    end
+
+    context 'when the page is not cacheable' do
+      let(:page) { double('page', cache?: false) }
+      before { allow(listener).to receive(:cacheable_request?).and_return(true) }
+
+      it 'sends a no-cache, private response and clears the etag' do
+        expect(listener).to receive(:set_expiry).with(nil, private: true, 'no-cache' => true)
+        expect(listener).to receive(:set_etag).with('')
+        director.set_cache_control
+      end
+    end
+
+    context 'when the request is not cacheable' do
+      let(:page) { double('page', cache?: true) }
+      before { allow(listener).to receive(:cacheable_request?).and_return(false) }
+
+      it 'sends a non-cacheable response' do
+        expect(listener).to receive(:set_expiry).with(nil, private: true, 'no-cache' => true)
+        expect(listener).to receive(:set_etag).with('')
+        director.set_cache_control
+      end
+    end
+  end
+end

--- a/spec/models/user_action_observer_spec.rb
+++ b/spec/models/user_action_observer_spec.rb
@@ -4,7 +4,14 @@ describe UserActionObserver do
   let(:observer) { UserActionObserver.instance }
   let(:user) { User.new }
 
-  after { Thread.current[:current_user] = nil }
+  # Restore the original thread-local rather than clobbering it with nil, so
+  # the spec stays isolated and order-independent.
+  around do |example|
+    original = Thread.current[:current_user]
+    example.run
+  ensure
+    Thread.current[:current_user] = original
+  end
 
   describe 'current_user' do
     it 'stores the current user on the class in thread-local storage' do

--- a/spec/models/user_action_observer_spec.rb
+++ b/spec/models/user_action_observer_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe UserActionObserver do
+  let(:observer) { UserActionObserver.instance }
+  let(:user) { User.new }
+
+  after { Thread.current[:current_user] = nil }
+
+  describe 'current_user' do
+    it 'stores the current user on the class in thread-local storage' do
+      UserActionObserver.current_user = user
+      expect(UserActionObserver.current_user).to eq(user)
+      expect(Thread.current[:current_user]).to eq(user)
+    end
+
+    it 'delegates the instance writer and reader to the class' do
+      observer.current_user = user
+      expect(UserActionObserver.current_user).to eq(user)
+      expect(observer.current_user).to eq(user)
+    end
+  end
+
+  describe 'callbacks' do
+    it 'does not raise on before_create' do
+      expect { observer.before_create(user) }.not_to raise_error
+    end
+
+    it 'does not raise on before_update' do
+      expect { observer.before_update(user) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds comprehensive model spec files to improve test coverage and documentation for various models and modules. The new specs test validations, associations, method behaviors, and edge cases for models such as `AssetType`, `PagePart`, `PageField`, `Status`, and others. These tests will help ensure correctness and maintainability of the codebase.

**Model and method behavior specs:**

* Added detailed specs for `AssetType`, covering registration, lookup, mime types, and utility methods.
* Added specs for `Status`, verifying initialization, lookup by symbol and id, and selectable statuses.
* Added specs for `PageContext`, including initialization, tag definitions, and error handling during rendering.
* Added specs for `RailsPage`, testing URL assignment and part creation/updating from hashes.
* Added specs for `FileNotFoundPage`, testing its page behavior and response code.
* Added specs for `PageAttachment` (`selected?`, `add_to_list_bottom`) and `PageField`/`PagePart` (validations and ordering). [[1]](diffhunk://#diff-013b64f5ff271a150a7aff1a42bba966b790a5ad83f93c97dcb7483ea549e0b7R1-R29) [[2]](diffhunk://#diff-98092ddcd859aeadc8e595bfa38c6879f4de68e7668f4ecc31a36b6294fd6e56R1-R15) [[3]](diffhunk://#diff-328bcfb409c32063869cba2808e94adbf9cb549f4ef1155e6a80462f00e707e4R1-R33)

**Module and filter specs:**

* Added specs for `MenuRenderer`, testing allowed children logic and exclusion handling.
* Added specs for `TextFilter` and a sample descendant, verifying filter delegation and descendant registration.
* Added specs for `HamlFilter`, testing Haml rendering and special tag handling.

**Extension and configuration specs:**

* Added specs for `SnippetFinder` and `SnippetTags`, covering snippet lookup, rendering, and error cases. [[1]](diffhunk://#diff-4641e244a8dfb9e0c237e88d2ca87b910e2ad7f2291713c4f157aa750436aec4R1-R27) [[2]](diffhunk://#diff-e6ab74f2afa1af7b05bae1746204eff83d3f427651960c5ae833a6eb48a9de78R1-R46)
* Added specs for `TrustyCms::Config`, testing boolean/selector logic, value handling, and settings definitions.

**Association specs:**

* Added specs for `AdminsSite`, verifying table name and belongs_to associations.