### PR TITLE
Helper Specs

### DIFF
--- a/spec/helpers/admin/references_helper_spec.rb
+++ b/spec/helpers/admin/references_helper_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Admin::ReferencesHelper, type: :helper do
+  describe '#class_of_page' do
+    it 'defaults to Page when no class_name param is present' do
+      allow(helper).to receive(:params).and_return({})
+      expect(helper.class_of_page).to eq(Page)
+    end
+
+    it 'constantizes the class_name param' do
+      allow(helper).to receive(:params).and_return(class_name: 'FileNotFoundPage')
+      expect(helper.class_of_page).to eq(FileNotFoundPage)
+    end
+  end
+
+  describe '#filter' do
+    it 'is nil for an unknown filter name' do
+      allow(helper).to receive(:params).and_return(filter_name: 'No Such Filter')
+      expect(helper.filter).to be_nil
+    end
+
+    it 'finds a text filter by its filter_name' do
+      HamlFilter # ensure the descendant is autoloaded
+      allow(helper).to receive(:params).and_return(filter_name: 'Haml')
+      expect(helper.filter).to eq(HamlFilter)
+    end
+  end
+
+  describe '#filter_reference' do
+    it 'explains when there is no filter on the page part' do
+      allow(helper).to receive(:params).and_return({})
+      expect(helper.filter_reference).to eq('There is no filter on the current page part.')
+    end
+
+    it 'explains when a filter has no documentation' do
+      HamlFilter
+      allow(helper).to receive(:params).and_return(filter_name: 'Haml')
+      expect(helper.filter_reference).to eq('There is no documentation on this filter.')
+    end
+  end
+
+  describe '#_display_name' do
+    it 'returns the page class display name for tags' do
+      allow(helper).to receive(:params).and_return(type: 'tags')
+      expect(helper._display_name).to eq(Page.display_name)
+    end
+
+    it 'returns the filter name for filters' do
+      HamlFilter
+      allow(helper).to receive(:params).and_return(type: 'filters', filter_name: 'Haml')
+      expect(helper._display_name).to eq('Haml')
+    end
+  end
+end

--- a/spec/helpers/admin/url_helper_spec.rb
+++ b/spec/helpers/admin/url_helper_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe Admin::UrlHelper, type: :helper do
+  describe '#format_path' do
+    it 'returns an empty string for a root or empty path' do
+      expect(helper.format_path('')).to eq('')
+      expect(helper.format_path('/')).to eq('')
+    end
+
+    it 'returns "Root" for a single segment' do
+      expect(helper.format_path('foo')).to eq('Root')
+    end
+
+    it 'returns "/" for two segments' do
+      expect(helper.format_path('foo/bar')).to eq('/')
+    end
+
+    it 'returns the middle subpath for deeper paths' do
+      expect(helper.format_path('foo/bar/baz')).to eq('/bar')
+      expect(helper.format_path('foo/bar/baz/qux')).to eq('/bar/baz')
+    end
+  end
+
+  describe '#extract_base_url' do
+    it 'keeps the scheme and host for a normal url' do
+      expect(helper.extract_base_url('http://example.com/some/page')).to eq('http://example.com')
+    end
+
+    it 'preserves the port for localhost urls' do
+      expect(helper.extract_base_url('http://localhost:3000/some/page')).to eq('http://localhost:3000')
+    end
+  end
+
+  describe '#default_route?' do
+    it 'is true for a plain Page' do
+      expect(helper.default_route?(Page.new)).to be(true)
+    end
+
+    it 'is false for a page subclass with no configured route' do
+      expect(helper.default_route?(FileNotFoundPage.new)).to be_falsey
+    end
+  end
+
+  describe '#lookup_page_path' do
+    it 'returns nil when no custom routes are configured' do
+      expect(helper.lookup_page_path(FileNotFoundPage.new)).to be_nil
+    end
+  end
+
+  describe '#build_url' do
+    it 'appends the page path for default-route pages' do
+      page = Page.new
+      allow(page).to receive(:path).and_return('/about')
+
+      expect(helper.build_url('http://example.com', page)).to eq('http://example.com/about')
+    end
+
+    it 'returns nil for a non-default page with no configured path' do
+      expect(helper.build_url('http://example.com', FileNotFoundPage.new)).to be_nil
+    end
+  end
+
+  describe '#generate_page_url' do
+    it 'combines the base url and page path' do
+      page = Page.new
+      allow(page).to receive(:path).and_return('/about')
+
+      expect(helper.generate_page_url('http://example.com/current', page)).to eq('http://example.com/about')
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe ApplicationHelper, type: :helper do
+  describe 'title and subtitle' do
+    it 'falls back to the default title and subtitle' do
+      allow(helper).to receive(:trusty_config).and_return({})
+
+      expect(helper.title).to eq('Trusty CMS')
+      expect(helper.subtitle).to eq('Publishing for Small Teams')
+      expect(helper.default_page_title).to eq('Trusty CMS - Publishing for Small Teams')
+    end
+
+    it 'uses the configured title and subtitle when present' do
+      allow(helper).to receive(:trusty_config)
+        .and_return('admin.title' => 'My Admin', 'admin.subtitle' => 'My Subtitle')
+
+      expect(helper.title).to eq('My Admin')
+      expect(helper.subtitle).to eq('My Subtitle')
+      expect(helper.default_page_title).to eq('My Admin - My Subtitle')
+    end
+  end
+
+  describe '#logged_in?' do
+    it 'is true when there is a current user' do
+      allow(helper).to receive(:current_user).and_return(User.new)
+      expect(helper.logged_in?).to be(true)
+    end
+
+    it 'is false when there is no current user' do
+      allow(helper).to receive(:current_user).and_return(nil)
+      expect(helper.logged_in?).to be(false)
+    end
+  end
+
+  describe '#admin? and #designer?' do
+    it 'reflects an admin user' do
+      user = instance_double(User, admin?: true, designer?: false)
+      allow(helper).to receive(:current_user).and_return(user)
+
+      expect(helper.admin?).to be(true)
+      expect(helper.designer?).to be(true)
+    end
+
+    it 'treats a designer as a designer but not an admin' do
+      user = instance_double(User, admin?: false, designer?: true)
+      allow(helper).to receive(:current_user).and_return(user)
+
+      expect(helper.admin?).to be(false)
+      expect(helper.designer?).to be(true)
+    end
+
+    it 'is false for both when there is no current user' do
+      allow(helper).to receive(:current_user).and_return(nil)
+
+      expect(helper.admin?).to be_falsey
+      expect(helper.designer?).to be_falsey
+    end
+  end
+
+  describe '#meta_errors? and #meta_label' do
+    it 'reports no meta errors and a "More" label' do
+      expect(helper.meta_errors?).to be(false)
+      expect(helper.meta_label).to eq('More')
+    end
+  end
+
+  describe '#translate_with_default' do
+    it 'returns the given name when there is no translation' do
+      expect(helper.translate_with_default('Some Untranslated Name')).to eq('Some Untranslated Name')
+    end
+  end
+
+  describe '#clean' do
+    it 'collapses duplicate slashes and strips a trailing slash from the path' do
+      expect(helper.clean('http://example.com/a//b/')).to eq('/a/b')
+    end
+  end
+
+  describe '#append_image_extension' do
+    it 'appends .png when no extension is present' do
+      expect(helper.send(:append_image_extension, 'admin/foo')).to eq('admin/foo.png')
+    end
+
+    it 'leaves an existing extension untouched' do
+      expect(helper.send(:append_image_extension, 'admin/foo.gif')).to eq('admin/foo.gif')
+    end
+  end
+
+  describe '#available_locales_select' do
+    it 'prepends a default option with a blank value' do
+      expect(helper.available_locales_select.first.last).to eq('')
+    end
+  end
+
+  describe '#body_classes' do
+    it 'starts as an empty, memoized array' do
+      expect(helper.body_classes).to eq([])
+      helper.body_classes << 'reversed'
+      expect(helper.body_classes).to eq(['reversed'])
+    end
+  end
+end

--- a/spec/helpers/scoped_helper_spec.rb
+++ b/spec/helpers/scoped_helper_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe ScopedHelper do
+  # ScopedHelper defines #title/#subtitle on its includer (via the included
+  # hook) and reads from #current_site, so mix it into a small host class and
+  # stub current_site rather than fight ApplicationHelper's own title/subtitle.
+  let(:host_class) do
+    Class.new do
+      include ScopedHelper
+      attr_accessor :site
+      def current_site
+        site
+      end
+    end
+  end
+
+  subject(:helper) { host_class.new }
+
+  def site_double(name:, subtitle:)
+    double('site', name: name, subtitle: subtitle)
+  end
+
+  describe '#title' do
+    it 'uses the current site name when present' do
+      helper.site = site_double(name: 'My Site', subtitle: '')
+      expect(helper.title).to eq('My Site')
+    end
+
+    it 'falls back to the configured admin title when the site name is blank' do
+      allow(TrustyCms::Config).to receive(:[]).with('admin.title').and_return('Configured Title')
+      helper.site = site_double(name: '', subtitle: '')
+      expect(helper.title).to eq('Configured Title')
+    end
+
+    it 'falls back to the default when both the site name and config are blank' do
+      allow(TrustyCms::Config).to receive(:[]).with('admin.title').and_return(nil)
+      helper.site = site_double(name: '', subtitle: '')
+      expect(helper.title).to eq('TrustyCMS')
+    end
+  end
+
+  describe '#subtitle' do
+    it 'uses the current site subtitle when present' do
+      helper.site = site_double(name: 'My Site', subtitle: 'My Subtitle')
+      expect(helper.subtitle).to eq('My Subtitle')
+    end
+
+    it 'falls back to the configured admin subtitle when the site subtitle is blank' do
+      allow(TrustyCms::Config).to receive(:[]).with('admin.subtitle').and_return('Configured Subtitle')
+      helper.site = site_double(name: 'My Site', subtitle: '')
+      expect(helper.subtitle).to eq('Configured Subtitle')
+    end
+
+    it 'falls back to the default when both the site subtitle and config are blank' do
+      allow(TrustyCms::Config).to receive(:[]).with('admin.subtitle').and_return(nil)
+      helper.site = site_double(name: 'My Site', subtitle: '')
+      expect(helper.subtitle).to eq('publishing for small teams')
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds comprehensive RSpec test coverage for several helper modules, focusing on verifying behavior for methods related to page references, URL formatting, application settings, and site-scoped titles and subtitles. The tests ensure correct fallbacks, method outputs, and edge case handling across these helpers.

**Helper spec additions:**

*Test coverage for helper modules:*

- [`spec/helpers/application_helper_spec.rb`](diffhunk://#diff-caa3def9981603cfcc31966f2bbe59aba2777727934cb2f06a375510582584c1R1-R102): Adds tests for `ApplicationHelper`, covering title/subtitle fallbacks, user role checks, meta error handling, string cleaning, image extension appending, locale select options, and body class memoization.
- [`spec/helpers/scoped_helper_spec.rb`](diffhunk://#diff-0131943c2a161523876217c0dc9fd49c12a74e25a4d874252cbd60af8a053e16R1-R60): Adds tests for `ScopedHelper`, verifying that site-specific and configuration-based fallbacks for `title` and `subtitle` behave as expected.
- [`spec/helpers/admin/references_helper_spec.rb`](diffhunk://#diff-2921f561c667f07b931cf944883fe14200438aa5b8f89f39faf85d43c0a127daR1-R54): Adds tests for `Admin::ReferencesHelper`, including page class resolution, filter lookup and documentation, display name logic, and filter reference explanations.
- [`spec/helpers/admin/url_helper_spec.rb`](diffhunk://#diff-02d5eaf7b02466def89f70284f94b1fb4f32fb01546251586d770ae1b6cb9ce1R1-R71): Adds tests for `Admin::UrlHelper`, covering path formatting, base URL extraction, default route detection, page path lookup, URL building, and page URL generation.