### PR TITLE
Upgrade specs for core monkeypatches, config caching, and auth

### DIFF
--- a/spec/controllers/admin/snippets_controller_spec.rb
+++ b/spec/controllers/admin/snippets_controller_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+# Exercises the full request cycle through Admin::ResourceController (the base
+# for most admin CRUD): before-action chain, permitted_params, response_for
+# dispatch, and the redirect/re-render paths. High blast radius for a Rails
+# upgrade, so keep this green before and after the bump.
+RSpec.describe Admin::SnippetsController, type: :controller do
+  routes { TrustyCms::Application.routes }
+
+  let(:user) { create(:admin) }
+
+  before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe 'GET #index' do
+    it 'succeeds for an authorized user' do
+      create(:snippet, name: 'listed')
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET #new' do
+    it 'succeeds' do
+      get :new
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST #create' do
+    it 'creates a snippet and redirects to the index' do
+      expect {
+        post :create, params: { snippet: { name: 'greeting', content: 'Hello' } }
+      }.to change(Snippet, :count).by(1)
+
+      expect(response).to be_redirect
+      expect(Snippet.find_by(name: 'greeting').content).to eq('Hello')
+    end
+
+    it 'records the creating user' do
+      post :create, params: { snippet: { name: 'owned', content: 'x' } }
+      expect(Snippet.find_by(name: 'owned').created_by_id).to eq(user.id)
+    end
+
+    # NOTE: Admin::ResourceController defines #rescue_action, but that is a
+    # Rails 2 hook the framework no longer calls, and it is not re-wired via
+    # rescue_from (only Admin::PagesController does that). So an invalid create
+    # currently raises RecordInvalid unhandled (a 500 in production) instead of
+    # re-rendering the form via `response_for :invalid`. Characterizing the
+    # current behavior; revisit if rescue_action is ever wired up.
+    it 'raises on invalid input and persists nothing (latent bug: rescue_action is dead)' do
+      expect {
+        post :create, params: { snippet: { name: '', content: 'x' } }
+      }.to raise_error(ActiveRecord::RecordInvalid)
+
+      expect(Snippet.where(name: '')).to be_empty
+    end
+  end
+
+  describe 'PUT #update' do
+    it 'updates the snippet and redirects' do
+      snippet = create(:snippet, name: 'editme', content: 'old')
+
+      put :update, params: { id: snippet.id, snippet: { content: 'new' } }
+
+      expect(response).to be_redirect
+      expect(snippet.reload.content).to eq('new')
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the snippet and redirects' do
+      snippet = create(:snippet, name: 'goner')
+
+      expect {
+        delete :destroy, params: { id: snippet.id }
+      }.to change(Snippet, :count).by(-1)
+
+      expect(response).to be_redirect
+    end
+  end
+
+  describe 'authorization' do
+    it 'denies a user without editor privileges' do
+      allow(controller).to receive(:current_user).and_return(create(:user, email: 'plain@example.com'))
+
+      get :index
+
+      expect(response).to be_redirect
+      expect(flash[:error]).to be_present
+    end
+  end
+end

--- a/spec/lib/active_record_extensions_spec.rb
+++ b/spec/lib/active_record_extensions_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+# ActiveRecord::Base monkeypatches. object_id_attr in particular relies on
+# .descendants and generated accessors, so pin its behaviour ahead of any
+# Rails upgrade. Exercised through PagePart, which uses it in production.
+describe 'ActiveRecord extensions' do
+  describe '.object_id_attr' do
+    it 'instantiates the matching descendant for the stored id' do
+      HamlFilter # ensure the descendant is autoloaded
+      part = PagePart.new(filter_id: 'Haml')
+      expect(part.filter).to be_a(HamlFilter)
+    end
+
+    it 'falls back to the base class when no descendant matches' do
+      part = PagePart.new(filter_id: nil)
+      expect(part.filter.class).to eq(TextFilter)
+    end
+
+    it 'memoises the built object until the id changes' do
+      part = PagePart.new(filter_id: nil)
+      first = part.filter
+      expect(part.filter).to equal(first)
+
+      HamlFilter
+      part.filter_id = 'Haml'
+      expect(part.filter).to be_a(HamlFilter)
+    end
+  end
+
+  describe '.validates_path' do
+    let(:model_class) do
+      Class.new(PageField) do
+        validates_path :content
+        def self.name
+          'PathValidatedField'
+        end
+      end
+    end
+
+    it 'is valid when the value resolves to a real page' do
+      page = FactoryBot.create(:page, slug: '/', status_id: Status[:published].id)
+      allow(Page).to receive(:find_by_path).and_return(page)
+
+      record = model_class.new(name: 'ref', content: '/')
+      record.valid?
+      expect(record.errors[:content]).to be_empty
+    end
+
+    it 'adds an error when the path is not found' do
+      allow(Page).to receive(:find_by_path).and_return(nil)
+
+      record = model_class.new(name: 'ref', content: '/missing')
+      record.valid?
+      expect(record.errors[:content]).to be_present
+    end
+
+    it 'adds an error when the path resolves to a FileNotFoundPage' do
+      allow(Page).to receive(:find_by_path).and_return(FileNotFoundPage.new)
+
+      record = model_class.new(name: 'ref', content: '/404')
+      record.valid?
+      expect(record.errors[:content]).to be_present
+    end
+  end
+end

--- a/spec/lib/login_system_spec.rb
+++ b/spec/lib/login_system_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+# LoginSystem is TrustyCms's custom role-based authorization layer, mixed into
+# ApplicationController. The class-level access rules are pure logic, so pin
+# them ahead of any Rails upgrade without needing a full request cycle.
+describe LoginSystem do
+  describe 'role-based access (.only_allow_access_to / .user_has_access_to_action?)' do
+    let(:controller_class) do
+      Class.new(ActionController::Base) do
+        include LoginSystem
+        only_allow_access_to :index, :show,
+                             when: %i[admin designer],
+                             denied_message: 'You need editor privileges.'
+      end
+    end
+
+    it 'records the declared permissions per action' do
+      perms = controller_class.controller_permissions[:index]
+      expect(perms[:when]).to eq(%i[admin designer])
+      expect(perms[:denied_message]).to eq('You need editor privileges.')
+    end
+
+    it 'grants access to a user with an allowed role' do
+      expect(controller_class.user_has_access_to_action?(User.new(admin: true), :index)).to be(true)
+      expect(controller_class.user_has_access_to_action?(User.new(designer: true), :show)).to be(true)
+    end
+
+    it 'denies a user without an allowed role' do
+      expect(controller_class.user_has_access_to_action?(User.new, :index)).to be(false)
+    end
+
+    it 'denies an anonymous (nil) user' do
+      expect(controller_class.user_has_access_to_action?(nil, :index)).to be(false)
+    end
+
+    it 'allows any action that has no declared restriction' do
+      expect(controller_class.user_has_access_to_action?(User.new, :unlisted_action)).to be(true)
+    end
+  end
+
+  describe 'conditional access (:if)' do
+    let(:controller_class) do
+      Class.new(ActionController::Base) do
+        include LoginSystem
+        only_allow_access_to :index, if: :allowed?
+        def allowed?
+          true
+        end
+      end
+    end
+
+    it 'delegates to the named predicate on the controller' do
+      expect(controller_class.user_has_access_to_action?(User.new, :index)).to be(true)
+    end
+  end
+
+  # NOTE: .login_required? / .login_required reference `filter_chain`, a Rails
+  # API removed years ago, and would raise NoMethodError if called. They are
+  # dead code today (only commented-out call sites remain), so they are not
+  # exercised here. Flagging for removal or repair rather than pinning.
+end

--- a/spec/lib/ostruct_spec.rb
+++ b/spec/lib/ostruct_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'ostruct'
+
+# lib/ostruct.rb reopens OpenStruct (originally patched for a Ruby upgrade) and
+# shadows the stdlib version via the load path. This is exactly the kind of
+# patch a Ruby/Rails upgrade can break, so pin the behaviour we rely on.
+describe 'OpenStruct patch' do
+  it 'is the project patch, not the stdlib implementation' do
+    expect(OpenStruct.instance_method(:initialize).source_location.first)
+      .to end_with('lib/ostruct.rb')
+  end
+
+  it 'builds accessors from a hash, symbolizing string keys' do
+    os = OpenStruct.new('a' => 1, :b => 2)
+    expect(os.a).to eq(1)
+    expect(os.b).to eq(2)
+  end
+
+  it 'returns nil for an unset member' do
+    expect(OpenStruct.new.anything).to be_nil
+  end
+
+  it 'assigns and reads a member dynamically' do
+    os = OpenStruct.new
+    os.foo = 'bar'
+    expect(os.foo).to eq('bar')
+  end
+
+  it 'raises ArgumentError when a setter is given the wrong arity' do
+    os = OpenStruct.new
+    expect { os.send(:foo=, 1, 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/lib/ostruct_spec.rb
+++ b/spec/lib/ostruct_spec.rb
@@ -5,10 +5,10 @@ require 'ostruct'
 # shadows the stdlib version via the load path. This is exactly the kind of
 # patch a Ruby/Rails upgrade can break, so pin the behaviour we rely on.
 describe 'OpenStruct patch' do
-  it 'is the project patch, not the stdlib implementation' do
-    expect(OpenStruct.instance_method(:initialize).source_location.first)
-      .to end_with('lib/ostruct.rb')
-  end
+it 'is the project patch, not the stdlib implementation' do
+  expect(OpenStruct.instance_method(:initialize).source_location.first)
+    .to eq(File.expand_path('../../lib/ostruct.rb', __dir__))
+end
 
   it 'builds accessors from a hash, symbolizing string keys' do
     os = OpenStruct.new('a' => 1, :b => 2)

--- a/spec/lib/string_extensions_spec.rb
+++ b/spec/lib/string_extensions_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'string_extensions/string_extensions'
+
+# Core-class monkeypatch: pin the behaviour so a Ruby/Rails upgrade that shifts
+# String#underscore/#humanize or stringex surfaces as a failure here.
+describe 'String extensions' do
+  describe '#symbolize' do
+    it 'collapses non-alphanumerics and underscores into a symbol' do
+      expect('Foo Bar!'.symbolize).to eq(:foo_bar)
+    end
+
+    it 'strips leading and trailing separators' do
+      expect('  Hello--World  '.symbolize).to eq(:hello_world)
+    end
+  end
+
+  describe '#titlecase' do
+    it 'upcases the first letter of each word' do
+      expect('hello world'.titlecase).to eq('Hello World')
+    end
+
+    it 'leaves already-capitalised words alone' do
+      expect('Hello World'.titlecase).to eq('Hello World')
+    end
+  end
+
+  describe '#to_name' do
+    it 'humanises and title-cases a class-style name' do
+      expect('FooBar'.to_name).to eq('Foo Bar')
+    end
+
+    it 'strips a trailing suffix when given one' do
+      expect('FooFilter'.to_name('Filter')).to eq('Foo')
+    end
+  end
+
+  describe '#parameterize and its aliases' do
+    it 'produces a url-style slug' do
+      expect('Hello World'.parameterize).to eq('hello-world')
+    end
+
+    it 'aliases to_slug, slugify and slugerize to parameterize' do
+      expect('Hello World'.to_slug).to eq('hello-world')
+      expect('Hello World'.slugify).to eq('hello-world')
+      expect('Hello World'.slugerize).to eq('hello-world')
+    end
+  end
+end

--- a/spec/lib/symbol_extensions_spec.rb
+++ b/spec/lib/symbol_extensions_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+# NOTE: symbol_extensions is not required anywhere in the app itself, so we
+# require it explicitly here. Kept as an upgrade tripwire since it depends on
+# String#symbolize (see string_extensions).
+require 'string_extensions/string_extensions'
+require 'symbol_extensions/symbol_extensions'
+
+describe 'Symbol extensions' do
+  describe '#symbolize' do
+    it 'normalises the symbol via String#symbolize' do
+      expect(:'Foo Bar'.symbolize).to eq(:foo_bar)
+    end
+  end
+end

--- a/spec/lib/trusty_cms/config_cache_spec.rb
+++ b/spec/lib/trusty_cms/config_cache_spec.rb
@@ -17,11 +17,14 @@ describe TrustyCms::Config, 'caching' do
   end
 
   describe '.ensure_cache_file' do
-    it 'creates the cache file' do
-      TrustyCms::Config.ensure_cache_file
-      expect(TrustyCms::Config.cache_file_exists?).to be(true)
-      expect(File.file?(TrustyCms::Config.cache_file)).to be(true)
-    end
+it 'creates the cache file' do
+  File.delete(TrustyCms::Config.cache_file) if File.exist?(TrustyCms::Config.cache_file)
+  expect(TrustyCms::Config.cache_file_exists?).to be(false)
+
+  TrustyCms::Config.ensure_cache_file
+  expect(TrustyCms::Config.cache_file_exists?).to be(true)
+  expect(File.file?(TrustyCms::Config.cache_file)).to be(true)
+end
   end
 
   describe '.initialize_cache' do

--- a/spec/lib/trusty_cms/config_cache_spec.rb
+++ b/spec/lib/trusty_cms/config_cache_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+# The cache layer of TrustyCms::Config leans on Rails.cache and File.mtime,
+# both of which can shift across Rails upgrades. Pin the round-trip. These
+# examples are read-only with respect to the config table (which is exempt
+# from truncation), so they never persist rows.
+describe TrustyCms::Config, 'caching' do
+  # Leave the cache in a good state for whatever runs next.
+  after { TrustyCms::Config.initialize_cache }
+
+  describe '.ensure_cache_file' do
+    it 'creates the cache file' do
+      TrustyCms::Config.ensure_cache_file
+      expect(TrustyCms::Config.cache_file_exists?).to be(true)
+      expect(File.file?(TrustyCms::Config.cache_file)).to be(true)
+    end
+  end
+
+  describe '.initialize_cache' do
+    it 'writes the full config hash into Rails.cache' do
+      TrustyCms::Config.initialize_cache
+      expect(Rails.cache.read('TrustyCms::Config')).to eq(TrustyCms::Config.to_hash)
+    end
+
+    it 'leaves the cache non-stale' do
+      TrustyCms::Config.initialize_cache
+      expect(TrustyCms::Config.stale_cache?).to be(false)
+    end
+  end
+
+  describe '.stale_cache?' do
+    it 'is true when the stored mtime no longer matches the cache file' do
+      TrustyCms::Config.initialize_cache
+      Rails.cache.write('TrustyCms.cache_mtime', Time.at(0))
+      expect(TrustyCms::Config.stale_cache?).to be(true)
+    end
+  end
+
+  describe '.[]' do
+    it 'reads a value through the cache' do
+      TrustyCms::Config.initialize_cache
+      key = TrustyCms::Config.to_hash.keys.first
+      expect(TrustyCms::Config[key]).to eq(TrustyCms::Config.to_hash[key])
+    end
+
+    it 'rebuilds a stale cache before returning a value' do
+      TrustyCms::Config.initialize_cache
+      key = TrustyCms::Config.to_hash.keys.first
+      Rails.cache.write('TrustyCms.cache_mtime', Time.at(0)) # force staleness
+
+      expect(TrustyCms::Config[key]).to eq(TrustyCms::Config.to_hash[key])
+      expect(TrustyCms::Config.stale_cache?).to be(false)
+    end
+  end
+
+  describe '.to_hash' do
+    it 'returns a hash keyed by config key' do
+      hash = TrustyCms::Config.to_hash
+      expect(hash).to be_a(Hash)
+      expect(hash.keys).to all(be_a(String))
+    end
+  end
+end

--- a/spec/lib/trusty_cms/config_cache_spec.rb
+++ b/spec/lib/trusty_cms/config_cache_spec.rb
@@ -1,12 +1,20 @@
 require 'spec_helper'
 
 # The cache layer of TrustyCms::Config leans on Rails.cache and File.mtime,
-# both of which can shift across Rails upgrades. Pin the round-trip. These
-# examples are read-only with respect to the config table (which is exempt
-# from truncation), so they never persist rows.
+# both of which can shift across Rails upgrades. Pin the round-trip.
 describe TrustyCms::Config, 'caching' do
-  # Leave the cache in a good state for whatever runs next.
-  after { TrustyCms::Config.initialize_cache }
+  # Seed a known key so the read/round-trip assertions can't pass vacuously on
+  # an empty config table. The config table is exempt from truncation, so this
+  # probe row is removed explicitly after each example.
+  let(:probe_key) { 'spec.cache_probe' }
+  let(:probe_value) { 'probe-value' }
+
+  before { TrustyCms::Config[probe_key] = probe_value }
+
+  after do
+    TrustyCms::Config.where(key: probe_key).delete_all
+    TrustyCms::Config.initialize_cache # leave the cache good for whatever runs next
+  end
 
   describe '.ensure_cache_file' do
     it 'creates the cache file' do
@@ -39,24 +47,23 @@ describe TrustyCms::Config, 'caching' do
   describe '.[]' do
     it 'reads a value through the cache' do
       TrustyCms::Config.initialize_cache
-      key = TrustyCms::Config.to_hash.keys.first
-      expect(TrustyCms::Config[key]).to eq(TrustyCms::Config.to_hash[key])
+      expect(TrustyCms::Config[probe_key]).to eq(probe_value)
     end
 
     it 'rebuilds a stale cache before returning a value' do
       TrustyCms::Config.initialize_cache
-      key = TrustyCms::Config.to_hash.keys.first
       Rails.cache.write('TrustyCms.cache_mtime', Time.at(0)) # force staleness
 
-      expect(TrustyCms::Config[key]).to eq(TrustyCms::Config.to_hash[key])
+      expect(TrustyCms::Config[probe_key]).to eq(probe_value)
       expect(TrustyCms::Config.stale_cache?).to be(false)
     end
   end
 
   describe '.to_hash' do
-    it 'returns a hash keyed by config key' do
+    it 'returns a hash keyed by config key, including seeded entries' do
       hash = TrustyCms::Config.to_hash
       expect(hash).to be_a(Hash)
+      expect(hash).to include(probe_key => probe_value)
       expect(hash.keys).to all(be_a(String))
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,7 @@ RSpec.configure do |config|
   # up.)
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Warden::Test::Helpers, type: :feature
+  config.before(:each, type: :feature) { Warden.test_mode! }
   config.after(:each, type: :feature) { Warden.test_reset! }
 
   config.before(:suite) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,12 +3,11 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rails'
-require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
-
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, timeout: 60)
-end
+# JS-driven system/feature tests use headless Chrome via Selenium. Poltergeist
+# (PhantomJS) was removed: it is unmaintained and does not run on modern
+# Ruby/Rails. The driver is registered lazily by Capybara, so this line does
+# not require selenium-webdriver unless a :js example actually runs.
+Capybara.javascript_driver = :selenium_chrome_headless
 
 require 'database_cleaner'
 DatabaseCleaner.strategy = :truncation, {except: %w[config]}
@@ -45,6 +44,13 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+
+  # Devise/Warden test helpers: sign_in for request specs, login_as for feature
+  # specs. (Previously the feature specs called login_as with no helper wired
+  # up.)
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Warden::Test::Helpers, type: :feature
+  config.after(:each, type: :feature) { Warden.test_reset! }
 
   config.before(:suite) do
     TrustyCms::Config.initialize_cache

--- a/spec/requests/admin/snippets_spec.rb
+++ b/spec/requests/admin/snippets_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Admin::Snippets requests', type: :request do
   describe 'authentication' do
     it 'redirects an unauthenticated HTML request to sign-in' do
       get '/admin/snippets'
-      expect(response).to redirect_to('/users/sign_in')
+      expect(response).to redirect_to(new_user_session_path)
     end
 
     it 'returns 401 for an unauthenticated JSON request' do

--- a/spec/requests/admin/snippets_spec.rb
+++ b/spec/requests/admin/snippets_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+# Full-stack smoke: routing -> Devise/Warden auth -> ResourceController ->
+# responder -> JSON render -> model -> DB. Uses the JSON endpoints so the smoke
+# doesn't depend on the (asset-pipeline-heavy) admin HTML layout, which can't be
+# rendered in this test environment. This is a high-value regression net for a
+# Rails/Ruby upgrade: it exercises the real request cycle end to end.
+RSpec.describe 'Admin::Snippets requests', type: :request do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  describe 'authentication' do
+    it 'redirects an unauthenticated HTML request to sign-in' do
+      get '/admin/snippets'
+      expect(response).to redirect_to('/users/sign_in')
+    end
+
+    it 'returns 401 for an unauthenticated JSON request' do
+      get '/admin/snippets.json'
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'authorization' do
+    it 'forbids a signed-in user without editor privileges (JSON)' do
+      sign_in FactoryBot.create(:user, email: 'plain@example.com')
+      get '/admin/snippets.json'
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  context 'when signed in as an admin' do
+    before { sign_in admin }
+
+    it 'lists snippets as JSON' do
+      FactoryBot.create(:snippet, name: 'listed', content: 'x')
+
+      get '/admin/snippets.json'
+
+      expect(response).to have_http_status(:ok)
+      names = JSON.parse(response.body).map { |s| s['name'] }
+      expect(names).to include('listed')
+    end
+
+    it 'creates a snippet via JSON' do
+      expect {
+        post '/admin/snippets.json', params: { snippet: { name: 'greeting', content: 'hi' } }
+      }.to change(Snippet, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(Snippet.find_by(name: 'greeting').content).to eq('hi')
+    end
+
+    it 'updates a snippet via JSON' do
+      snippet = FactoryBot.create(:snippet, name: 'editme', content: 'old')
+
+      put "/admin/snippets/#{snippet.id}.json", params: { snippet: { content: 'new' } }
+
+      expect(response).to have_http_status(:ok)
+      expect(snippet.reload.content).to eq('new')
+    end
+
+    # NOTE: destroy DOES remove the record, but the JSON/XML responder in
+    # Admin::ResourceController calls `head :deleted`, and :deleted is not a
+    # valid Rack status symbol, so the response is a 500. Characterizing the
+    # current behavior; the record removal is correct, only the status is wrong.
+    it 'destroys the record but returns 500 from head :deleted (latent bug)' do
+      snippet = FactoryBot.create(:snippet, name: 'goner')
+
+      expect {
+        delete "/admin/snippets/#{snippet.id}.json"
+      }.to change(Snippet, :count).by(-1)
+
+      expect(response).to have_http_status(:internal_server_error)
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a comprehensive suite of new and improved specs to pin critical behaviors in preparation for Rails and Ruby upgrades. The main focus is on end-to-end request cycles, controller logic, model extensions, and core-class monkeypatches, ensuring that any regressions or breaking changes in framework upgrades are surfaced early. It also updates the test environment to use a modern JavaScript driver and wires up authentication helpers for feature and request specs.

**Test Suite Modernization and Infrastructure:**

* Switched Capybara's JavaScript driver from the deprecated `poltergeist` (PhantomJS) to `selenium_chrome_headless` for compatibility with modern Ruby/Rails, and removed all Poltergeist setup. (`spec/rails_helper.rb`)
* Added Devise/Warden test helpers for request and feature specs, ensuring authentication helpers like `sign_in` and `login_as` work as expected. (`spec/rails_helper.rb`)

**End-to-End and Controller Specs for Admin::Snippets:**

* Added a full-stack request spec for `Admin::Snippets` covering authentication, authorization, and all CRUD JSON endpoints, characterizing current behaviors and known bugs. (`spec/requests/admin/snippets_spec.rb`)
* Introduced a controller spec for `Admin::SnippetsController` to exercise the full Rails controller lifecycle, including before-actions, parameter whitelisting, and error handling. (`spec/controllers/admin/snippets_controller_spec.rb`)

**Core Extensions and Model Behavior Pinning:**

* Added specs for ActiveRecord extensions, including `.object_id_attr` and `.validates_path`, to ensure correct descendant instantiation and path validation behaviors. (`spec/lib/active_record_extensions_spec.rb`)
* Added specs for core-class monkeypatches on `OpenStruct`, `String`, and `Symbol`, verifying project-specific behaviors that could break on Ruby/Rails upgrades. (`spec/lib/ostruct_spec.rb`, `spec/lib/string_extensions_spec.rb`, `spec/lib/symbol_extensions_spec.rb`) [[1]](diffhunk://#diff-95c61a419ca3eaec2d8dcd72e4cd309eebb60917c5bf78b1196247c3efe23891R1-R33) [[2]](diffhunk://#diff-610d992901db0dfd68f46dd425a70072e33a2fb4c0c7032dfecf7ccd69808ef7R1-R48) [[3]](diffhunk://#diff-904eba4a18551dc95101b1407fd23c0496c0342f3d75d6fe6341e0fd931b6d16R1-R14)

**Authorization and Config Caching:**

* Added specs for the custom `LoginSystem` role-based access logic, pinning the permission system at the class level. (`spec/lib/login_system_spec.rb`)
* Added tests for the `TrustyCms::Config` cache layer, verifying cache file creation, cache staleness detection, and round-trip config reads. (`spec/lib/trusty_cms/config_cache_spec.rb`)