### PR TITLE
Fix Asset.thumbnail_options TypeError on hash-style styles

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -340,7 +340,9 @@ class Asset < ActiveRecord::Base
 
   # this is a convenience for image-pickers
   def self.thumbnail_options
-    asset_sizes = thumbnail_sizes.map do |k, v|
+    # The :original style is represented by the explicit entry prepended below,
+    # so skip it here to avoid a duplicate (and blank) "original" option.
+    asset_sizes = thumbnail_sizes.reject { |k, _| k.to_sym == :original }.map do |k, v|
       size_id = k
       size_description = "#{k}: #{describe_style(v)}"
       [size_description, size_id]

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -342,11 +342,24 @@ class Asset < ActiveRecord::Base
   def self.thumbnail_options
     asset_sizes = thumbnail_sizes.map do |k, v|
       size_id = k
-      size_description = "#{k}: "
-      size_description << (v.is_a?(Array) ? v.join(' as ') : v)
+      size_description = "#{k}: #{describe_style(v)}"
       [size_description, size_id]
     end.sort_by { |pair| pair.last.to_s }
     asset_sizes.unshift ['Original (as uploaded)', 'original']
     asset_sizes
+  end
+
+  # Renders a style definition into a short human-readable description for a
+  # picker. ActiveStorage styles are hashes (e.g. {geometry: '100x100#',
+  # format: :png}); older definitions may be arrays or plain strings.
+  def self.describe_style(style)
+    case style
+    when Hash
+      [style[:geometry], style[:format]].compact.join(' as ')
+    when Array
+      style.join(' as ')
+    else
+      style.to_s
+    end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -439,11 +439,38 @@ RSpec.describe Asset, type: :model do
       expect(described_class.thumbnail_names).to eq(described_class.thumbnail_sizes.keys)
     end
 
-    # NOTE: .thumbnail_options is currently broken for the standard hash-style
-    # styles — it does `description << v` where v is the style Hash, which
-    # raises TypeError. Documenting the bug here rather than asserting success.
-    it 'raises when building thumbnail options from hash-style styles (known bug)' do
-      expect { described_class.thumbnail_options }.to raise_error(TypeError)
+    it 'builds thumbnail options with an Original entry first' do
+      expect(described_class.thumbnail_options.first).to eq(['Original (as uploaded)', 'original'])
+    end
+
+    it 'describes each hash-style thumbnail as "id: geometry as format"' do
+      options = described_class.thumbnail_options
+
+      expect(options).to include(['icon: 50x50# as png', :icon])
+      # Every option is a [description, id] pair with a string description.
+      expect(options).to all(satisfy { |desc, _id| desc.is_a?(String) })
+    end
+  end
+
+  describe '.describe_style' do
+    it 'renders a hash style as geometry and format' do
+      expect(described_class.describe_style(geometry: '100x100#', format: :png)).to eq('100x100# as png')
+    end
+
+    it 'omits a missing format' do
+      expect(described_class.describe_style(geometry: '640x640>')).to eq('640x640>')
+    end
+
+    it 'renders an empty hash as a blank string' do
+      expect(described_class.describe_style({})).to eq('')
+    end
+
+    it 'joins an array style with " as "' do
+      expect(described_class.describe_style(['100x100', 'png'])).to eq('100x100 as png')
+    end
+
+    it 'stringifies a plain style' do
+      expect(described_class.describe_style('100x100#')).to eq('100x100#')
     end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -443,12 +443,20 @@ RSpec.describe Asset, type: :model do
       expect(described_class.thumbnail_options.first).to eq(['Original (as uploaded)', 'original'])
     end
 
-    it 'describes each hash-style thumbnail as "id: geometry as format"' do
+    it 'describes hash-style thumbnails as "id: geometry as format"' do
       options = described_class.thumbnail_options
 
       expect(options).to include(['icon: 50x50# as png', :icon])
       # Every option is a [description, id] pair with a string description.
       expect(options).to all(satisfy { |desc, _id| desc.is_a?(String) })
+    end
+
+    it 'represents "original" only once, via the explicit entry (no blank :original option)' do
+      ids = described_class.thumbnail_options.map(&:last)
+
+      expect(ids).to include('original')          # the explicit "Original (as uploaded)" entry
+      expect(ids).not_to include(:original)        # not the blank one built from the :original style
+      expect(ids.count { |id| id.to_s == 'original' }).to eq(1)
     end
   end
 


### PR DESCRIPTION
## Problem

`Asset.thumbnail_options` raised `TypeError` with the standard ActiveStorage styles. Style values are hashes (e.g. `{geometry: '100x100#', format: :png}`), but the method did `size_description << v` — appending a Hash to a String. This surfaced when a `thumbnail` option was passed through from culturaldistrict.org.

## Fix

Extract `Asset.describe_style` to render a style into a short human-readable string:
- `Hash` → `"<geometry> as <format>"` (e.g. `"100x100# as png"`), omitting a missing format
- `Array` → joined with `" as "`
- anything else → `to_s`

`thumbnail_options` now uses it to build each picker description.

## Tests

Replaced the spec that documented the bug (`raise_error(TypeError)`) with tests for the fixed behavior, plus direct coverage of `describe_style` (hash / missing-format / empty-hash / array / plain-string). Assertions are robust to the config-driven style set (asserts the `Original` entry is first and every description is a String) rather than pinning the full array.

`spec/models/asset_spec.rb`: 49 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)