### PR TITLE
Replace :deleted with :ok and update the spec

### DIFF
--- a/app/controllers/admin/resource_controller.rb
+++ b/app/controllers/admin/resource_controller.rb
@@ -42,7 +42,7 @@ class Admin::ResourceController < ApplicationController
     r.update.publish(:xml, :json) { head :ok }
     r.update.default { redirect_to redirect_url }
 
-    r.destroy.publish(:xml, :json) { head :deleted }
+    r.destroy.publish(:xml, :json) { head :ok }
     r.destroy.default { redirect_to redirect_url }
   end
 

--- a/spec/requests/admin/snippets_spec.rb
+++ b/spec/requests/admin/snippets_spec.rb
@@ -59,18 +59,23 @@ RSpec.describe 'Admin::Snippets requests', type: :request do
       expect(snippet.reload.content).to eq('new')
     end
 
-    # NOTE: destroy DOES remove the record, but the JSON/XML responder in
-    # Admin::ResourceController calls `head :deleted`, and :deleted is not a
-    # valid Rack status symbol, so the response is a 500. Characterizing the
-    # current behavior; the record removal is correct, only the status is wrong.
-    it 'destroys the record but returns 500 from head :deleted (latent bug)' do
+    it 'destroys the record via JSON' do
       snippet = FactoryBot.create(:snippet, name: 'goner')
 
       expect {
         delete "/admin/snippets/#{snippet.id}.json"
       }.to change(Snippet, :count).by(-1)
 
-      expect(response).to have_http_status(:internal_server_error)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to be_empty
+    end
+
+    it 'destroys the record and redirects (HTML)' do
+      snippet = FactoryBot.create(:snippet, name: 'goner-html')
+      expect {
+        delete "/admin/snippets/#{snippet.id}"
+      }.to change(Snippet, :count).by(-1)
+      expect(response).to redirect_to(admin_snippets_path)
     end
   end
 end


### PR DESCRIPTION
This pull request fixes an issue with the HTTP status code returned when deleting resources via the admin API, ensuring correct responses for both JSON/XML and HTML formats. It also updates the corresponding tests to reflect and verify the new behavior.

**Bug fix: Correct destroy response status**

- Changed the destroy action in `Admin::ResourceController` to return HTTP 200 OK (`head :ok`) instead of the invalid `:deleted` status for JSON/XML responses, resolving a previous bug that caused a 500 Internal Server Error.

**Test updates:**

- Updated the JSON destroy test in `spec/requests/admin/snippets_spec.rb` to expect a 200 OK response with an empty body, and added a new test to verify that destroying a resource via HTML redirects as expected.