### PR TITLE
Part 2: Fix multi-site logout + per-site authorization (pending telemetry #1045/#1046)

### DIFF
--- a/app/controllers/admin/resource_controller.rb
+++ b/app/controllers/admin/resource_controller.rb
@@ -6,6 +6,7 @@ class Admin::ResourceController < ApplicationController
   helper_method :model, :current_object, :models, :current_objects, :model_symbol, :plural_model_symbol, :model_class, :model_name, :plural_model_name
   before_action :populate_format
   before_action :never_cache
+  before_action :require_access_to_current_site
   before_action :load_models, only: :index
   before_action :load_model, only: %i[new create edit update remove destroy]
   before_action :set_owner_or_editor, only: %i[new create update]
@@ -261,5 +262,35 @@ class Admin::ResourceController < ApplicationController
       params[symbol].permit!
     end
     params
+  end
+
+  # Multi-site authorization. Authentication is intentionally global (see the
+  # unscoped overrides on User), so a signed-in user is always correctly
+  # identified regardless of the current site. This check enforces the separate
+  # concern of *authorization*: a non-admin user may only reach the admin of a
+  # site they are assigned to. It replaces the old behaviour where a site
+  # mismatch made the User lookup return nil and silently logged the user out
+  # (and, under the current_site race, briefly exposed another site's data).
+  #
+  # No-op unless the multi_site extension is active (current_site is defined by
+  # MultiSite::ApplicationControllerExtensions).
+  def require_access_to_current_site
+    return unless respond_to?(:current_site)
+    return if site_access_permitted?(current_user, current_site)
+
+    @denied_site = current_site
+    @accessible_sites = current_user&.sites&.to_a || []
+    render 'admin/site_access_denied', status: :forbidden, layout: false
+  end
+
+  # Pure authorization predicate (no request state), so it is unit-testable
+  # without activating the multi_site extension. A nil user is "permitted" here
+  # because authenticate_user! has already handled the unauthenticated case.
+  def site_access_permitted?(user, site)
+    return true if user.nil?
+    return true if user.admin?
+    return true unless site.is_a?(Site)
+
+    user.sites.exists?(id: site.id)
   end
 end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -12,7 +12,8 @@ class Admin::SessionsController < Devise::SessionsController
   private
 
   def find_user
-    User.find_by(email: params[:user][:email])
+    # Unscoped: authentication must not be site-scoped (see User auth overrides).
+    User.unscoped.find_by(email: params[:user][:email])
   end
 
   def authenticated?(user)

--- a/app/controllers/admin/two_factor_controller.rb
+++ b/app/controllers/admin/two_factor_controller.rb
@@ -25,7 +25,8 @@ class Admin::TwoFactorController < ApplicationController
       redirect_to after_sign_in_path_for(current_user) and return
     end
 
-    @user = User.find_by(id: session[:pre_2fa_user_id])
+    # Unscoped: authentication must not be site-scoped (see User auth overrides).
+    @user = User.unscoped.find_by(id: session[:pre_2fa_user_id])
 
     if !@user&.otp_required_for_login || session_expired?
       reset_session

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,4 +78,19 @@ class User < ActiveRecord::Base
     errors.add :password, 'Complexity requirement not met. Length should be 12 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character.'
   end
 
+  # Authentication must never be site-scoped. The multi_site extension gives User
+  # a site-based default_scope (INNER JOIN admins_sites for Page.current_site).
+  # Because current_site is process-global mutable state and a single process
+  # serves many sites, that scope can point at the wrong site when Devise
+  # deserializes the session user, excluding the row and logging the user out.
+  # Run every auth lookup unscoped so identity is independent of the current site.
+  def self.serialize_from_session(key, salt)
+    record = unscoped { to_adapter.get(key) }
+    record if record && record.authenticatable_salt == salt
+  end
+
+  def self.find_first_by_auth_conditions(tainted_conditions, opts = {})
+    unscoped { super }
+  end
+
 end

--- a/app/views/admin/site_access_denied.html.haml
+++ b/app/views/admin/site_access_denied.html.haml
@@ -1,0 +1,31 @@
+!!!
+%html{ lang: "en" }
+  %head
+    %meta{ charset: "utf-8" }
+    %meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
+    %title Access denied
+    :css
+      body { font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: #f4f5f7; color: #2f3337; margin: 0; padding: 4rem 1rem; }
+      .box { max-width: 560px; margin: 0 auto; background: #fff; border: 1px solid #e2e4e8; border-radius: 10px; padding: 2rem 2.25rem; box-shadow: 0 1px 3px rgba(0,0,0,.06); }
+      h1 { margin: 0 0 .75rem; font-size: 1.35rem; }
+      p { line-height: 1.5; }
+      ul { padding-left: 1.25rem; }
+      .actions { margin-top: 1.5rem; }
+      a { color: #0a58ca; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+  %body
+    .box
+      %h1 Access denied
+      %p
+        You don't have access to the
+        %strong= @denied_site.try(:name).presence || "requested"
+        site.
+      - if @accessible_sites.present?
+        %p You can manage the following #{'site'.pluralize(@accessible_sites.size)}:
+        %ul
+          - @accessible_sites.each do |site|
+            %li= site.name
+      - else
+        %p Your account isn't assigned to any site yet. Please contact an administrator.
+      .actions
+        = link_to "Log out", destroy_user_session_path

--- a/spec/controllers/admin/resource_controller_authorization_spec.rb
+++ b/spec/controllers/admin/resource_controller_authorization_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+# Authorization for the multi_site setup (issue #1040): authentication is global
+# (see User auth overrides), so a separate check enforces that a non-admin user
+# may only reach the admin of a site they are assigned to. This exercises the
+# pure predicate; Site / AdminsSite / User#sites all exist in engine core, so it
+# does not require the multi_site extension to be active.
+describe Admin::ResourceController, type: :controller do
+  subject(:controller_instance) { described_class.new }
+
+  let(:site_a) { create(:site) }
+  let(:site_b) { create(:site) }
+
+  def permitted?(user, site)
+    controller_instance.send(:site_access_permitted?, user, site)
+  end
+
+  context 'a non-admin user assigned to site_a only' do
+    let(:editor) do
+      user = create(:user, admin: false)
+      AdminsSite.create!(admin: user, site: site_a)
+      user
+    end
+
+    it 'is permitted on their assigned site' do
+      expect(permitted?(editor, site_a)).to be true
+    end
+
+    it 'is denied on a site they are not assigned to' do
+      expect(permitted?(editor, site_b)).to be false
+    end
+  end
+
+  it 'permits an admin on any site (site authorization is bypassed)' do
+    admin = create(:admin, admin: true)
+    expect(permitted?(admin, site_a)).to be true
+    expect(permitted?(admin, site_b)).to be true
+  end
+
+  it 'permits when there is no current site (nothing to authorize against)' do
+    editor = create(:user, admin: false)
+    expect(permitted?(editor, nil)).to be true
+  end
+
+  it 'permits a nil user (authenticate_user! owns the unauthenticated case)' do
+    expect(permitted?(nil, site_a)).to be true
+  end
+
+  it 'denies a non-admin user with no site assignments' do
+    editor = create(:user, admin: false)
+    expect(permitted?(editor, site_a)).to be false
+  end
+end

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :site do
+    sequence(:name) { |n| "Site #{n}" }
+    sequence(:base_domain) { |n| "site#{n}.example.com" }
+    # domain is stored as a regexp string and validated for uniqueness.
+    sequence(:domain) { |n| "site#{n}\\.example\\.com" }
+  end
+end

--- a/spec/models/user_auth_scope_spec.rb
+++ b/spec/models/user_auth_scope_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+# Load the REAL multi_site scoping code (the extension is not activated in the
+# dummy test app, so we require the module directly). This lets us reproduce the
+# exact production site-scope on User rather than a hand-rolled stand-in, so the
+# test breaks if `user_scope_condition` ever changes.
+require File.expand_path(
+  '../../vendor/extensions/multi-site-extension/lib/multi_site/scoped_model', __dir__
+)
+
+# Regression test for issue #1040: non-admin (site-scoped) editors were being
+# logged out because Devise deserializes the session user through User's
+# site-scoped default_scope, and Page.current_site (process-global) frequently
+# points at a site the editor is not assigned to -> the INNER JOIN excludes the
+# row -> Devise sees nil -> logout.
+#
+# The fix makes all authentication lookups run `unscoped` (see User). Here we
+# apply the real site-scope to User, point current_site at the WRONG site, and
+# assert every auth entry point still resolves the editor.
+describe 'User authentication is never site-scoped (issue #1040)', type: :model do
+  # Apply the production multi_site scope to User for this example group only,
+  # then fully restore it. config.order = "random", so leaking the default_scope
+  # would corrupt unrelated specs.
+  around do |example|
+    original_default_scopes = User.default_scopes.dup
+
+    # Mirror MultiSite::PageExtensions' class-level current_site accessor.
+    added_page_accessor = false
+    unless Page.respond_to?(:current_site)
+      Page.singleton_class.send(:attr_accessor, :current_site)
+      added_page_accessor = true
+    end
+
+    unless User.singleton_class.include?(MultiSite::ScopedModel::ScopedClassMethods)
+      User.extend(MultiSite::ScopedModel::ScopedClassMethods)
+    end
+    # The real production default_scope for User (scoped_model.rb:28).
+    User.class_eval { default_scope { joins(user_scope_condition) } }
+
+    begin
+      example.run
+    ensure
+      User.default_scopes = original_default_scopes
+      if added_page_accessor
+        Page.singleton_class.send(:remove_method, :current_site)
+        Page.singleton_class.send(:remove_method, :current_site=)
+      end
+    end
+  end
+
+  let(:site_a) { create(:site) }
+  let(:site_b) { create(:site) }
+
+  # An editor assigned to site_a ONLY (row in admins_sites for site_a, none for site_b).
+  let(:editor) do
+    user = create(:user, email: 'editor@example.com')
+    AdminsSite.create!(admin: user, site: site_a)
+    user
+  end
+
+  before do
+    # Simulate a request whose current site is the WRONG one for this editor.
+    Page.current_site = site_b
+  end
+
+  it 'confirms the site-scope really does exclude the editor (bug precondition)' do
+    # Scoped lookup: INNER JOIN admins_sites on site_b -> editor (site_a only) excluded.
+    expect(User.where(id: editor.id).first).to be_nil
+    # Unscoped: the editor obviously still exists.
+    expect(User.unscoped.where(id: editor.id).first).to eq(editor)
+  end
+
+  it 'serialize_from_session resolves the editor despite the wrong current_site' do
+    expect(
+      User.serialize_from_session(editor.id, editor.authenticatable_salt)
+    ).to eq(editor)
+  end
+
+  it 'find_first_by_auth_conditions resolves the editor despite the wrong current_site' do
+    expect(
+      User.find_first_by_auth_conditions(email: editor.email)
+    ).to eq(editor)
+  end
+
+  it 'find_for_authentication resolves the editor despite the wrong current_site' do
+    expect(
+      User.find_for_authentication(email: editor.email)
+    ).to eq(editor)
+  end
+
+  it 'the login-path email lookup resolves the editor despite the wrong current_site' do
+    # Mirrors Admin::SessionsController#find_user after the fix.
+    expect(
+      User.unscoped.find_by(email: editor.email)
+    ).to eq(editor)
+  end
+end


### PR DESCRIPTION
## Problem

Two related symptoms in the multi-site setup, both rooted in the same design flaw:
1. **Spurious logouts** — non-admin (site-scoped) editors get bounced to the login screen mid-session (e.g. after saving a page). Admins assigned to all sites are immune.
2. **Cross-site access** — a one-site editor can briefly reach another site's data before being kicked (reported), because the underlying `current_site` state races.

Fixes #1040. Follow-up: #1042.

## Root cause

The `multi_site` extension uses **one crude mechanism — site-scoping the `User` lookup — to do two different jobs**: proving *who you are* (authentication) and deciding *which sites you may manage* (authorization).

`User` gets `default_scope { joins(user_scope_condition) }` (`scoped_model.rb:28,112-116`) — an `INNER JOIN admins_sites` on `Page.current_site`. `Page.current_site` is process-global mutable state (`page_extensions.rb:33-38`), and one process serves many hosts. Devise deserializes the session user every request through that scope, so when `current_site` points at a site the user isn't in (via the cross-thread race, or a host fallback to `Site.default`), the lookup returns `nil` → logout.

## Fix (two intentional, separated concerns)

**1. Authentication is global.** All auth lookups run `unscoped`, so a valid user is always identified regardless of the current site:
- `User.serialize_from_session` (session deserialization)
- `User.find_first_by_auth_conditions` (login + password reset; `find_for_authentication` delegates to it)
- `Admin::SessionsController#find_user`, and the `Admin::TwoFactorController` pre-2FA lookup

This alone stops the logouts — but it also removes the side effect that blocked cross-site access, so:

**2. Authorization is explicit.** `Admin::ResourceController` now runs `require_access_to_current_site` after authentication: a non-admin may only reach the admin of a site in their `sites` (admins bypass). On denial it renders a **403 "Access denied"** page **without** destroying the session (no global logout). The decision is a pure, unit-tested predicate and the whole check is a no-op unless `multi_site` is active.

## Verification

**Unit (engine suite): 401 examples, 0 failures.**
- `spec/models/user_auth_scope_spec.rb` — applies the *real* multi_site scope to `User`, points `current_site` at the wrong site, asserts every auth entry point still resolves the editor (fails before the fix).
- `spec/controllers/admin/resource_controller_authorization_spec.rb` — the authorization predicate (own site allowed, foreign denied, admin bypass, no-site denied).

**End-to-end against culturaldistrict.org (multi_site active), via HTTP:**
| Scenario | Result |
|---|---|
| Unauthenticated → /admin | 302 → /users/sign_in |
| One-site editor, own site | authenticated, allowed |
| One-site editor, foreign site | **403 Access denied** (still logged in, no data) |
| Admin, any site | allowed |

## Not in this PR (follow-up #1042)

`Page.current_site` is still process-global/thread-unsafe. That race is the deeper root cause of the transient cross-site bleed. #1042 tracks making it request-local (`ActiveSupport::CurrentAttributes`) while preserving the accessor API (no consuming-app changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
