### PR TITLE
Telemetry: instrument CMS site-scope auth failures (diagnostic for #1040)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,12 @@ class ApplicationController < ActionController::Base
   prepend_view_path("#{TRUSTY_CMS_ROOT}/app/views")
 
   protect_from_forgery with: :exception
+  # Capture the request host before authentication runs so the site-scope logout
+  # telemetry (issue #1040) can compare the host's site to the (global) current
+  # site. Thread.current is per-thread and safe across concurrent requests —
+  # unlike the class-level Page.current_site the telemetry is investigating.
+  prepend_before_action { Thread.current[:trusty_request_host] = request.host }
+  after_action { Thread.current[:trusty_request_host] = nil }
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_timezone

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,8 +9,10 @@ class ApplicationController < ActionController::Base
   # telemetry (issue #1040) can compare the host's site to the (global) current
   # site. Thread.current is per-thread and safe across concurrent requests —
   # unlike the class-level Page.current_site the telemetry is investigating.
-  prepend_before_action { Thread.current[:trusty_request_host] = request.host }
-  after_action { Thread.current[:trusty_request_host] = nil }
+  # An around_action (prepended so it wraps authenticate_user!) guarantees the
+  # value is cleared even if the request raises, so it can't leak into the next
+  # request handled by the same thread.
+  prepend_around_action :with_request_host_for_telemetry
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_timezone
@@ -58,6 +60,13 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def with_request_host_for_telemetry
+    Thread.current[:trusty_request_host] = request.host
+    yield
+  ensure
+    Thread.current[:trusty_request_host] = nil
+  end
 
   def set_mailer
     ActionMailer::Base.default_url_options[:host] = request.host_with_port

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+require 'trusty_cms/site_scope_auth_reporter'
+
 class User < ActiveRecord::Base
   has_many :pages, foreign_key: :created_by_id
   self.table_name = 'admins'
@@ -76,6 +78,17 @@ class User < ActiveRecord::Base
     return false if password.blank? || password =~ /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}$/
 
     errors.add :password, 'Complexity requirement not met. Length should be 12 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character.'
+  end
+
+  # Observe-only instrument for the intermittent logout bug (issue #1040). This
+  # keeps Devise's exact (site-scoped) behavior — it returns the scoped lookup
+  # unchanged, so a mismatch still logs the user out exactly as before — and only
+  # reports when a valid user was excluded by the site scope. See
+  # TrustyCms::SiteScopeAuthReporter. The behavior-change fix is separate (PR #1041).
+  def self.serialize_from_session(key, salt)
+    record = to_adapter.get(key)
+    TrustyCms::SiteScopeAuthReporter.report_miss(key) if record.nil?
+    record if record && record.authenticatable_salt == salt
   end
 
 end

--- a/lib/trusty_cms/site_scope_auth_reporter.rb
+++ b/lib/trusty_cms/site_scope_auth_reporter.rb
@@ -1,0 +1,99 @@
+module TrustyCms
+  # Observe-only telemetry for the intermittent CMS logout bug (diagnostic for
+  # issue #1040). It changes NO behavior.
+  #
+  # When the multi_site extension is active, `User` carries a site-scoped
+  # default_scope (an INNER JOIN on admins_sites for `Page.current_site`).
+  # Devise deserializes the session user every request through that scope, so if
+  # `current_site` points at a site the user is not assigned to, the lookup
+  # returns nil and the user is logged out. Because `current_site` is
+  # process-global mutable state shared across Puma threads, we suspect this is
+  # usually a race (the user IS on a site they belong to, but the global was
+  # clobbered by a concurrent request for another host).
+  #
+  # This reporter fires only when a session lookup misses BUT the user actually
+  # exists (unscoped) — i.e. a valid user was excluded by the site scope — and
+  # records enough context to tell a race from a genuine cross-site access or an
+  # unmatched-host fallback. It never raises into the auth path.
+  module SiteScopeAuthReporter
+    MESSAGE = 'CMS site-scope logout (possible current_site race)'.freeze
+
+    module_function
+
+    def report_miss(key)
+      return unless multi_site_scoped?
+
+      excluded = User.unscoped { User.to_adapter.get(key) }
+      return if excluded.nil? # ordinary unknown/expired session — not our bug
+
+      context = build_context(excluded)
+      Rails.logger.warn("[multi_site] #{MESSAGE} #{context.to_json}")
+      Honeybadger.notify(MESSAGE, context: context) if defined?(Honeybadger)
+      nil
+    rescue StandardError => e
+      # Telemetry must never break authentication.
+      Rails.logger.error("[multi_site] SiteScopeAuthReporter error: #{e.class}: #{e.message}")
+      nil
+    end
+
+    # Only meaningful when User is actually site-scoped by the multi_site
+    # extension; otherwise the scoped and unscoped lookups are identical.
+    def multi_site_scoped?
+      User.respond_to?(:is_site_scoped?) && User.is_site_scoped?
+    end
+
+    def build_context(user)
+      current = current_site
+      host = Thread.current[:trusty_request_host]
+      expected = expected_site_for(host)
+      site_ids = user.site_ids
+
+      {
+        user_id: user.id,
+        user_admin: user.admin?,
+        user_site_ids: site_ids,
+        current_site_id: current&.id,
+        current_site_name: current&.name,
+        current_site_domain_blank: current.present? && current.domain.blank?,
+        request_host: host,
+        expected_site_id: expected&.id,
+        expected_site_name: expected&.name,
+        classification: classify(site_ids, current, expected, host),
+        thread: Thread.current.object_id,
+        at: Time.now.utc.iso8601,
+      }
+    end
+
+    # race               -> user belongs to the host's site, but current_site is
+    #                       something else (the global was clobbered)
+    # genuine_cross_site -> user hit a host whose site they are not assigned to
+    # host_unmatched     -> request host matched no site (asset/unknown host);
+    #                       current_site falls back to the default site
+    # no_host_captured   -> ran outside a captured request (e.g. rake/console)
+    def classify(site_ids, current, expected, host)
+      return 'no_host_captured' if host.blank?
+      return 'host_unmatched' if expected.nil?
+      return 'race' if site_ids.include?(expected.id) && (current.nil? || site_ids.exclude?(current.id))
+      return 'genuine_cross_site' if site_ids.exclude?(expected.id)
+
+      'unknown'
+    end
+
+    def current_site
+      Page.current_site if Page.respond_to?(:current_site)
+    end
+
+    # Mirrors Site.find_for_host's matching but WITHOUT the Site.default /
+    # catchall fallback, so telemetry never creates a record and returns nil when
+    # the host matches no site.
+    def expected_site_for(host)
+      return nil if host.blank?
+
+      Site.where.not(domain: nil).detect do |site|
+        host == site.base_domain || host =~ Regexp.compile(site.domain.to_s)
+      end
+    rescue RegexpError
+      nil
+    end
+  end
+end

--- a/lib/trusty_cms/site_scope_auth_reporter.rb
+++ b/lib/trusty_cms/site_scope_auth_reporter.rb
@@ -85,15 +85,24 @@ module TrustyCms
 
     # Mirrors Site.find_for_host's matching but WITHOUT the Site.default /
     # catchall fallback, so telemetry never creates a record and returns nil when
-    # the host matches no site.
+    # the host matches no site (which is what drives the host_unmatched
+    # classification). A blank domain compiles to a regexp that matches every
+    # host, so blank domains are matched only by exact base_domain, never by the
+    # regexp.
     def expected_site_for(host)
       return nil if host.blank?
 
-      Site.where.not(domain: nil).detect do |site|
-        host == site.base_domain || host =~ Regexp.compile(site.domain.to_s)
+      Site.all.detect do |site|
+        host == site.base_domain || domain_regexp_match?(site, host)
       end
+    end
+
+    def domain_regexp_match?(site, host)
+      return false if site.domain.blank?
+
+      !(host =~ Regexp.compile(site.domain)).nil?
     rescue RegexpError
-      nil
+      false
     end
   end
 end

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :site do
+    sequence(:name) { |n| "Site #{n}" }
+    sequence(:base_domain) { |n| "site#{n}.example.com" }
+    # domain is stored as a regexp string and validated for uniqueness.
+    sequence(:domain) { |n| "site#{n}\\.example\\.com" }
+  end
+end

--- a/spec/models/user_serialize_telemetry_spec.rb
+++ b/spec/models/user_serialize_telemetry_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+# Load the REAL multi_site scoping code (the extension is not activated in the
+# dummy test app) so we reproduce the exact production site-scope on User.
+require File.expand_path(
+  '../../vendor/extensions/multi-site-extension/lib/multi_site/scoped_model', __dir__
+)
+
+# Telemetry for the intermittent CMS logout (issue #1040). This is observe-only:
+# it must NOT change Devise's behavior, and must report exactly when a valid user
+# is excluded from session deserialization by the site scope.
+describe 'User.serialize_from_session telemetry (issue #1040)', type: :model do
+  # Apply the production multi_site User scope for this example group only, then
+  # restore it (config.order = "random", so a leaked default_scope would corrupt
+  # other specs).
+  around do |example|
+    original_default_scopes = User.default_scopes.dup
+
+    added_page_accessor = false
+    unless Page.respond_to?(:current_site)
+      Page.singleton_class.send(:attr_accessor, :current_site)
+      added_page_accessor = true
+    end
+
+    unless User.singleton_class.include?(MultiSite::ScopedModel::ScopedClassMethods)
+      User.extend(MultiSite::ScopedModel::ScopedClassMethods)
+    end
+    User.class_eval { default_scope { joins(user_scope_condition) } }
+
+    begin
+      example.run
+    ensure
+      User.default_scopes = original_default_scopes
+      if added_page_accessor
+        Page.singleton_class.send(:remove_method, :current_site)
+        Page.singleton_class.send(:remove_method, :current_site=)
+      end
+      Thread.current[:trusty_request_host] = nil
+    end
+  end
+
+  let(:site_a) { create(:site) }
+  let(:site_b) { create(:site) }
+
+  # Editor assigned to site_a only.
+  let(:editor) do
+    user = create(:user, email: 'editor@example.com')
+    AdminsSite.create!(admin: user, site: site_a)
+    user
+  end
+
+  def serialize
+    User.serialize_from_session(editor.id, editor.authenticatable_salt)
+  end
+
+  context 'when current_site excludes an otherwise-valid user (the bug)' do
+    before { Page.current_site = site_b }
+
+    it 'still returns nil — behavior is unchanged vs the scoped default' do
+      expect(serialize).to be_nil
+    end
+
+    it 'reports the miss to the log with context and a classification' do
+      Thread.current[:trusty_request_host] = site_a.base_domain # host they belong to
+      expect(Rails.logger).to receive(:warn).with(/CMS site-scope logout/)
+      serialize
+    end
+
+    it 'classifies a host-they-belong-to mismatch as a race' do
+      Thread.current[:trusty_request_host] = site_a.base_domain
+      ctx = TrustyCms::SiteScopeAuthReporter.build_context(editor)
+      expect(ctx[:classification]).to eq('race')
+      expect(ctx[:user_id]).to eq(editor.id)
+      expect(ctx[:current_site_id]).to eq(site_b.id)
+    end
+
+    it 'classifies a host they are not assigned to as genuine_cross_site' do
+      Thread.current[:trusty_request_host] = site_b.base_domain # host they do NOT belong to
+      ctx = TrustyCms::SiteScopeAuthReporter.build_context(editor)
+      expect(ctx[:classification]).to eq('genuine_cross_site')
+    end
+  end
+
+  context 'when current_site includes the user (normal case)' do
+    before { Page.current_site = site_a }
+
+    it 'returns the user and reports nothing' do
+      expect(Rails.logger).not_to receive(:warn).with(/CMS site-scope logout/)
+      expect(serialize).to eq(editor)
+    end
+  end
+
+  context 'when the session key maps to no user at all' do
+    before { Page.current_site = site_a }
+
+    it 'reports nothing (ordinary expired/invalid session)' do
+      expect(Rails.logger).not_to receive(:warn).with(/CMS site-scope logout/)
+      expect(User.serialize_from_session(0, 'nope')).to be_nil
+    end
+  end
+
+  it 'never raises into the auth path if telemetry blows up' do
+    Page.current_site = site_b
+    allow(TrustyCms::SiteScopeAuthReporter).to receive(:build_context).and_raise('boom')
+    allow(Rails.logger).to receive(:error)
+
+    result = nil
+    expect { result = serialize }.not_to raise_error
+    expect(result).to be_nil
+    expect(Rails.logger).to have_received(:error).with(/SiteScopeAuthReporter error/)
+  end
+end

--- a/spec/models/user_serialize_telemetry_spec.rb
+++ b/spec/models/user_serialize_telemetry_spec.rb
@@ -25,12 +25,17 @@ describe 'User.serialize_from_session telemetry (issue #1040)', type: :model do
     unless User.singleton_class.include?(MultiSite::ScopedModel::ScopedClassMethods)
       User.extend(MultiSite::ScopedModel::ScopedClassMethods)
     end
+    # `extend` above can't be undone, so pin is_site_scoped? explicitly per
+    # example (true here, false in ensure) to keep the telemetry from leaking on
+    # into unrelated specs after this group runs.
+    User.define_singleton_method(:is_site_scoped?) { true }
     User.class_eval { default_scope { joins(user_scope_condition) } }
 
     begin
       example.run
     ensure
       User.default_scopes = original_default_scopes
+      User.define_singleton_method(:is_site_scoped?) { false }
       if added_page_accessor
         Page.singleton_class.send(:remove_method, :current_site)
         Page.singleton_class.send(:remove_method, :current_site=)
@@ -78,6 +83,13 @@ describe 'User.serialize_from_session telemetry (issue #1040)', type: :model do
       Thread.current[:trusty_request_host] = site_b.base_domain # host they do NOT belong to
       ctx = TrustyCms::SiteScopeAuthReporter.build_context(editor)
       expect(ctx[:classification]).to eq('genuine_cross_site')
+    end
+
+    it 'classifies a request host that matches no site as host_unmatched' do
+      Thread.current[:trusty_request_host] = 'nomatch.invalid'
+      ctx = TrustyCms::SiteScopeAuthReporter.build_context(editor)
+      expect(ctx[:expected_site_id]).to be_nil
+      expect(ctx[:classification]).to eq('host_unmatched')
     end
   end
 


### PR DESCRIPTION
Part 1 of the #1040 work — **observe-only telemetry, zero behavior change** — to confirm the suspected `current_site` race in production before shipping the behavior change (PR #1041).

Closes #1045. Refs #1040.

## Change

- **`User.serialize_from_session`** — keeps Devise's exact scoped behavior (returns the scoped lookup, so a mismatch still logs the user out exactly as on master) and only *observes*: when the scoped lookup misses, it asks the reporter whether a valid user was excluded by the site scope.
- **`TrustyCms::SiteScopeAuthReporter`** (`lib/`) — `Rails.logger.warn` always + `Honeybadger.notify` guarded by `defined?(Honeybadger)`, with context and a `classification` (`race` / `genuine_cross_site` / `host_unmatched`). Exception-safe: never raises into auth.
- **`ApplicationController`** — captures `request.host` per-request in `Thread.current` (per-thread safe) before auth so the reporter can compute the host's expected site.

## Safety

No redirects, no failure-app, no auth-behavior change. Honeybadger is a soft dependency (guarded), so the engine keeps no new hard dep. The reporter’s only cost is one extra `unscoped` lookup, and only on a deserialization miss.

## Tests

`spec/models/user_serialize_telemetry_spec.rb` applies the **real** `multi_site` scope to `User` and asserts:
- `serialize_from_session` still returns `nil` on a mismatch (**behavior unchanged**),
- telemetry fires with the right context/classification only when a valid user is scope-excluded,
- nothing fires on a normal hit or an unknown session,
- a reporter exception is swallowed (auth unaffected).

Full engine suite green (**397 examples, 0 failures**).

## Rollout

Deploy, watch Honeybadger/logs ~1 week, then use the `classification` mix to decide whether to proceed with **PR #1041** (unscope + per-site authorization) and/or **#1042** (request-local `current_site`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
